### PR TITLE
add sync send trait bounds to codec errors

### DIFF
--- a/heed-traits/src/lib.rs
+++ b/heed-traits/src/lib.rs
@@ -4,11 +4,11 @@ use std::error::Error;
 pub trait BytesEncode {
     type EItem: ?Sized;
 
-    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error>>;
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error + Sync + Send>>;
 }
 
 pub trait BytesDecode<'a> {
     type DItem: 'a;
 
-    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error>>;
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error + Sync + Send>>;
 }

--- a/heed-types/src/cow_slice.rs
+++ b/heed-types/src/cow_slice.rs
@@ -24,7 +24,7 @@ pub struct CowSlice<'a, T>(std::marker::PhantomData<&'a T>);
 impl<'a, T: Pod> BytesEncode for CowSlice<'a, T> {
     type EItem = &'a [T];
 
-    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error>> {
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error + Sync + Send>> {
         try_cast_slice(item).map(Cow::Borrowed).map_err(Into::into)
     }
 }
@@ -32,7 +32,7 @@ impl<'a, T: Pod> BytesEncode for CowSlice<'a, T> {
 impl<'a, T: Pod> BytesDecode<'a> for CowSlice<'_, T> {
     type DItem = Cow<'a, [T]>;
 
-    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error>> {
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error + Sync + Send>> {
         match try_cast_slice(bytes) {
             Ok(items) => Ok(Cow::Borrowed(items)),
             Err(PodCastError::AlignmentMismatch) => Ok(Cow::Owned(pod_collect_to_vec(bytes))),

--- a/heed-types/src/cow_type.rs
+++ b/heed-types/src/cow_type.rs
@@ -30,7 +30,7 @@ pub struct CowType<T>(std::marker::PhantomData<T>);
 impl<T: Pod> BytesEncode for CowType<T> {
     type EItem = T;
 
-    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error>> {
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error + Sync + Send>> {
         Ok(Cow::Borrowed(bytes_of(item)))
     }
 }
@@ -38,7 +38,7 @@ impl<T: Pod> BytesEncode for CowType<T> {
 impl<'a, T: Pod> BytesDecode<'a> for CowType<T> {
     type DItem = Cow<'a, T>;
 
-    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error>> {
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error + Sync + Send>> {
         match try_from_bytes(bytes) {
             Ok(item) => Ok(Cow::Borrowed(item)),
             Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => {

--- a/heed-types/src/lib.rs
+++ b/heed-types/src/lib.rs
@@ -64,7 +64,7 @@ pub struct DecodeIgnore;
 impl heed_traits::BytesDecode<'_> for DecodeIgnore {
     type DItem = ();
 
-    fn bytes_decode(_bytes: &[u8]) -> Result<Self::DItem, Box<dyn Error>> {
+    fn bytes_decode(_bytes: &[u8]) -> Result<Self::DItem, Box<dyn Error + Sync + Send>> {
         Ok(())
     }
 }

--- a/heed-types/src/owned_slice.rs
+++ b/heed-types/src/owned_slice.rs
@@ -24,7 +24,7 @@ pub struct OwnedSlice<'a, T>(std::marker::PhantomData<&'a T>);
 impl<'a, T: Pod> BytesEncode for OwnedSlice<'a, T> {
     type EItem = &'a [T];
 
-    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error>> {
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error + Sync + Send>> {
         CowSlice::bytes_encode(item)
     }
 }
@@ -32,7 +32,7 @@ impl<'a, T: Pod> BytesEncode for OwnedSlice<'a, T> {
 impl<'a, T: Pod + 'a> BytesDecode<'a> for OwnedSlice<'_, T> {
     type DItem = Vec<T>;
 
-    fn bytes_decode(bytes: &[u8]) -> Result<Self::DItem, Box<dyn Error>> {
+    fn bytes_decode(bytes: &[u8]) -> Result<Self::DItem, Box<dyn Error + Sync + Send>> {
         CowSlice::bytes_decode(bytes).map(Cow::into_owned)
     }
 }

--- a/heed-types/src/owned_type.rs
+++ b/heed-types/src/owned_type.rs
@@ -30,7 +30,7 @@ pub struct OwnedType<T>(std::marker::PhantomData<T>);
 impl<T: Pod> BytesEncode for OwnedType<T> {
     type EItem = T;
 
-    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error>> {
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error + Sync + Send>> {
         CowType::bytes_encode(item)
     }
 }
@@ -38,7 +38,7 @@ impl<T: Pod> BytesEncode for OwnedType<T> {
 impl<'a, T: Pod> BytesDecode<'a> for OwnedType<T> {
     type DItem = T;
 
-    fn bytes_decode(bytes: &[u8]) -> Result<Self::DItem, Box<dyn Error>> {
+    fn bytes_decode(bytes: &[u8]) -> Result<Self::DItem, Box<dyn Error + Sync + Send>> {
         CowType::<T>::bytes_decode(bytes).map(Cow::into_owned)
     }
 }

--- a/heed-types/src/serde_bincode.rs
+++ b/heed-types/src/serde_bincode.rs
@@ -15,7 +15,7 @@ where
 {
     type EItem = T;
 
-    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error>> {
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error + Sync + Send>> {
         bincode::serialize(item).map(Cow::Owned).map_err(Into::into)
     }
 }
@@ -26,7 +26,7 @@ where
 {
     type DItem = T;
 
-    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error>> {
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error + Sync + Send>> {
         bincode::deserialize(bytes).map_err(Into::into)
     }
 }

--- a/heed-types/src/serde_json.rs
+++ b/heed-types/src/serde_json.rs
@@ -15,7 +15,7 @@ where
 {
     type EItem = T;
 
-    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error>> {
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error + Sync + Send>> {
         serde_json::to_vec(item).map(Cow::Owned).map_err(Into::into)
     }
 }
@@ -26,7 +26,7 @@ where
 {
     type DItem = T;
 
-    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error>> {
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error + Sync + Send>> {
         serde_json::from_slice(bytes).map_err(Into::into)
     }
 }

--- a/heed-types/src/str.rs
+++ b/heed-types/src/str.rs
@@ -13,7 +13,7 @@ pub struct Str<'a> {
 impl<'a> BytesEncode for Str<'a> {
     type EItem = &'a str;
 
-    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error>> {
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error + Sync + Send>> {
         try_cast_slice(item.as_bytes()).map(Cow::Borrowed).map_err(Into::into)
     }
 }
@@ -21,7 +21,7 @@ impl<'a> BytesEncode for Str<'a> {
 impl<'a> BytesDecode<'a> for Str<'_> {
     type DItem = &'a str;
 
-    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error>> {
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error + Sync + Send>> {
         str::from_utf8(bytes).map_err(Into::into)
     }
 }

--- a/heed-types/src/unaligned_slice.rs
+++ b/heed-types/src/unaligned_slice.rs
@@ -17,7 +17,7 @@ pub struct UnalignedSlice<'a, T>(std::marker::PhantomData<&'a T>);
 impl<'a, T: Pod> BytesEncode for UnalignedSlice<'a, T> {
     type EItem = &'a [T];
 
-    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error>> {
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error + Sync + Send>> {
         try_cast_slice(item).map(Cow::Borrowed).map_err(Into::into)
     }
 }
@@ -25,7 +25,7 @@ impl<'a, T: Pod> BytesEncode for UnalignedSlice<'a, T> {
 impl<'a, T: Pod> BytesDecode<'a> for UnalignedSlice<'_, T> {
     type DItem = &'a [T];
 
-    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error>> {
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error + Sync + Send>> {
         try_cast_slice(bytes).map_err(Into::into)
     }
 }

--- a/heed-types/src/unaligned_type.rs
+++ b/heed-types/src/unaligned_type.rs
@@ -23,7 +23,7 @@ pub struct UnalignedType<T>(std::marker::PhantomData<T>);
 impl<T: Pod> BytesEncode for UnalignedType<T> {
     type EItem = T;
 
-    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error>> {
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error + Sync + Send>> {
         Ok(Cow::Borrowed(bytes_of(item)))
     }
 }
@@ -31,7 +31,7 @@ impl<T: Pod> BytesEncode for UnalignedType<T> {
 impl<'a, T: Pod> BytesDecode<'a> for UnalignedType<T> {
     type DItem = &'a T;
 
-    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error>> {
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Box<dyn Error + Sync + Send>> {
         try_from_bytes(bytes).map_err(Into::into)
     }
 }

--- a/heed-types/src/unit.rs
+++ b/heed-types/src/unit.rs
@@ -10,7 +10,7 @@ pub struct Unit;
 impl BytesEncode for Unit {
     type EItem = ();
 
-    fn bytes_encode(_item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error>> {
+    fn bytes_encode(_item: &Self::EItem) -> Result<Cow<[u8]>, Box<dyn Error + Sync + Send>> {
         Ok(Cow::Borrowed(&[]))
     }
 }
@@ -18,7 +18,7 @@ impl BytesEncode for Unit {
 impl BytesDecode<'_> for Unit {
     type DItem = ();
 
-    fn bytes_decode(bytes: &[u8]) -> Result<Self::DItem, Box<dyn Error>> {
+    fn bytes_decode(bytes: &[u8]) -> Result<Self::DItem, Box<dyn Error + Sync + Send>> {
         if bytes.is_empty() {
             Ok(())
         } else {

--- a/heed/src/lazy_decode.rs
+++ b/heed/src/lazy_decode.rs
@@ -12,7 +12,7 @@ pub struct LazyDecode<C>(marker::PhantomData<C>);
 impl<'a, C: 'static> heed_traits::BytesDecode<'a> for LazyDecode<C> {
     type DItem = Lazy<'a, C>;
 
-    fn bytes_decode(bytes: &'a [u8]) -> StdResult<Self::DItem, Box<dyn StdError>> {
+    fn bytes_decode(bytes: &'a [u8]) -> StdResult<Self::DItem, Box<dyn StdError + Sync + Send>> {
         Ok(Lazy { data: bytes, _phantom: marker::PhantomData })
     }
 }

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -84,8 +84,8 @@ pub type UntypedDatabase = Database<types::ByteSlice<'static>, types::ByteSlice<
 pub enum Error {
     Io(io::Error),
     Mdb(MdbError),
-    Encoding(Box<dyn StdError>),
-    Decoding(Box<dyn StdError>),
+    Encoding(Box<dyn StdError + Sync + Send>),
+    Decoding(Box<dyn StdError + Sync + Send>),
     InvalidDatabaseTyping,
     DatabaseClosing,
 }


### PR DESCRIPTION
This makes is possible to send heed errors across threads. This was a breaking API change.
