### PR TITLE
throw error when dest copy file exists

### DIFF
--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -424,7 +424,7 @@ impl Env {
 
     // TODO rename into `copy_to_file` for more clarity
     pub fn copy_to_path<P: AsRef<Path>>(&self, path: P, option: CompactionOption) -> Result<File> {
-        let file = File::create(&path)?;
+        let file = File::options().create_new(true).write(true).open(&path)?;
         let fd = get_file_fd(&file);
 
         unsafe { self.copy_to_fd(fd, option)?; }


### PR DESCRIPTION
Prevent the user to overwrite a file when copying a db to it, to avoid destructive write.

The motivation for this is a SEGV encountered when I accidentally copied my db into itself.
