### PR TITLE
Introduce move_on_key method on cursors

### DIFF
--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -14,6 +14,7 @@ pub mod cursor_op {
     pub const MDB_FIRST: MDB_cursor_op = ffi::MDB_FIRST;
     pub const MDB_LAST: MDB_cursor_op = ffi::MDB_LAST;
     pub const MDB_SET_RANGE: MDB_cursor_op = ffi::MDB_SET_RANGE;
+    pub const MDB_SET_KEY: MDB_cursor_op = ffi::MDB_SET_KEY;
     pub const MDB_PREV: MDB_cursor_op = ffi::MDB_PREV;
     pub const MDB_NEXT: MDB_cursor_op = ffi::MDB_NEXT;
     pub const MDB_GET_CURRENT: MDB_cursor_op = ffi::MDB_GET_CURRENT;


### PR DESCRIPTION
implement the `move_on_key` cursor method, to allow more efficient sequential scans.

After giving it some thought, I have also added a `current` method on the iterator. This is because `move_on_key` can land you somewhere else that you actually expect, and it is useful to be able to know where. 