### PR TITLE
add a method to compute the size of an env

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,5 @@
-disable_all_formatting = true
+unstable_features = true
+
+use_small_heuristics = "max"
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/heed-types/src/cow_slice.rs
+++ b/heed-types/src/cow_slice.rs
@@ -1,9 +1,10 @@
 use std::borrow::Cow;
 use std::{mem, ptr};
 
-use crate::aligned_to;
 use heed_traits::{BytesDecode, BytesEncode};
 use zerocopy::{AsBytes, FromBytes, LayoutVerified};
+
+use crate::aligned_to;
 
 /// Describes a slice that must be [memory aligned] and
 /// will be reallocated if it is not.

--- a/heed-types/src/cow_type.rs
+++ b/heed-types/src/cow_type.rs
@@ -1,9 +1,10 @@
 use std::borrow::Cow;
 use std::{mem, ptr};
 
-use crate::aligned_to;
 use heed_traits::{BytesDecode, BytesEncode};
 use zerocopy::{AsBytes, FromBytes, LayoutVerified};
+
+use crate::aligned_to;
 
 /// Describes a type that must be [memory aligned] and
 /// will be reallocated if it is not.

--- a/heed-types/src/lib.rs
+++ b/heed-types/src/lib.rs
@@ -78,7 +78,6 @@ impl heed_traits::BytesDecode<'_> for DecodeIgnore {
 
 #[cfg(feature = "serde-bincode")]
 pub use self::serde_bincode::SerdeBincode;
-
 #[cfg(feature = "serde-json")]
 pub use self::serde_json::SerdeJson;
 

--- a/heed-types/src/owned_slice.rs
+++ b/heed-types/src/owned_slice.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
+use heed_traits::{BytesDecode, BytesEncode};
 use zerocopy::{AsBytes, FromBytes};
 
 use crate::CowSlice;
-use heed_traits::{BytesDecode, BytesEncode};
 
 /// Describes a [`Vec`] of types that are totally owned (doesn't
 /// hold any reference to the original slice).

--- a/heed-types/src/owned_type.rs
+++ b/heed-types/src/owned_type.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
-use crate::CowType;
 use heed_traits::{BytesDecode, BytesEncode};
 use zerocopy::{AsBytes, FromBytes};
+
+use crate::CowType;
 
 /// Describes a type that is totally owned (doesn't
 /// hold any reference to the original slice).

--- a/heed-types/src/serde_bincode.rs
+++ b/heed-types/src/serde_bincode.rs
@@ -1,6 +1,7 @@
+use std::borrow::Cow;
+
 use heed_traits::{BytesDecode, BytesEncode};
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 
 /// Describes a type that is [`Serialize`]/[`Deserialize`] and uses `bincode` to do so.
 ///

--- a/heed-types/src/serde_json.rs
+++ b/heed-types/src/serde_json.rs
@@ -1,6 +1,7 @@
+use std::borrow::Cow;
+
 use heed_traits::{BytesDecode, BytesEncode};
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 
 /// Describes a type that is [`Serialize`]/[`Deserialize`] and uses `serde_json` to do so.
 ///

--- a/heed-types/src/str.rs
+++ b/heed-types/src/str.rs
@@ -1,6 +1,8 @@
-use crate::UnalignedSlice;
-use heed_traits::{BytesDecode, BytesEncode};
 use std::borrow::Cow;
+
+use heed_traits::{BytesDecode, BytesEncode};
+
+use crate::UnalignedSlice;
 
 /// Describes an [`str`].
 pub struct Str;

--- a/heed-types/src/unit.rs
+++ b/heed-types/src/unit.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+
 use heed_traits::{BytesDecode, BytesEncode};
 
 /// Describes the `()` type.

--- a/heed/examples/all-types-poly.rs
+++ b/heed/examples/all-types-poly.rs
@@ -129,9 +129,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // or iterate over ranges too!!!
     let range = BEI64::new(35)..=BEI64::new(42);
-    let rets: Result<Vec<(BEI64, _)>, _> = db
-        .range::<_, OwnedType<BEI64>, Unit, _>(&wtxn, &range)?
-        .collect();
+    let rets: Result<Vec<(BEI64, _)>, _> =
+        db.range::<_, OwnedType<BEI64>, Unit, _>(&wtxn, &range)?.collect();
 
     println!("{:?}", rets);
 

--- a/heed/src/cursor.rs
+++ b/heed/src/cursor.rs
@@ -16,10 +16,7 @@ impl<'txn> RoCursor<'txn> {
 
         unsafe { mdb_result(ffi::mdb_cursor_open(txn.txn, dbi, &mut cursor))? }
 
-        Ok(RoCursor {
-            cursor,
-            _marker: marker::PhantomData,
-        })
+        Ok(RoCursor { cursor, _marker: marker::PhantomData })
     }
 
     pub fn current(&mut self) -> Result<Option<(&'txn [u8], &'txn [u8])>> {
@@ -188,9 +185,7 @@ pub struct RwCursor<'txn> {
 
 impl<'txn> RwCursor<'txn> {
     pub(crate) fn new<T>(txn: &'txn RwTxn<T>, dbi: ffi::MDB_dbi) -> Result<RwCursor<'txn>> {
-        Ok(RwCursor {
-            cursor: RoCursor::new(txn, dbi)?,
-        })
+        Ok(RwCursor { cursor: RoCursor::new(txn, dbi)? })
     }
 
     /// Delete the entry the cursor is currently pointing to.

--- a/heed/src/db/polymorph.rs
+++ b/heed/src/db/polymorph.rs
@@ -219,12 +219,7 @@ impl PolyDatabase {
         let mut value = mem::MaybeUninit::uninit();
 
         let result = unsafe {
-            mdb_result(ffi::mdbx_dbi_sequence(
-                txn.txn.txn,
-                self.dbi,
-                value.as_mut_ptr(),
-                increment,
-            ))
+            mdb_result(ffi::mdbx_dbi_sequence(txn.txn.txn, self.dbi, value.as_mut_ptr(), increment))
         };
 
         match result {
@@ -284,12 +279,7 @@ impl PolyDatabase {
         let mut data_val = mem::MaybeUninit::uninit();
 
         let result = unsafe {
-            mdb_result(ffi::mdb_get(
-                txn.txn,
-                self.dbi,
-                &mut key_val,
-                data_val.as_mut_ptr(),
-            ))
+            mdb_result(ffi::mdb_get(txn.txn, self.dbi, &mut key_val, data_val.as_mut_ptr()))
         };
 
         match result {
@@ -1640,13 +1630,7 @@ impl PolyDatabase {
         let flags = 0;
 
         unsafe {
-            mdb_result(ffi::mdb_put(
-                txn.txn.txn,
-                self.dbi,
-                &mut key_val,
-                &mut data_val,
-                flags,
-            ))?
+            mdb_result(ffi::mdb_put(txn.txn.txn, self.dbi, &mut key_val, &mut data_val, flags))?
         }
 
         Ok(())
@@ -1708,13 +1692,7 @@ impl PolyDatabase {
         let flags = ffi::MDB_APPEND;
 
         unsafe {
-            mdb_result(ffi::mdb_put(
-                txn.txn.txn,
-                self.dbi,
-                &mut key_val,
-                &mut data_val,
-                flags,
-            ))?
+            mdb_result(ffi::mdb_put(txn.txn.txn, self.dbi, &mut key_val, &mut data_val, flags))?
         }
 
         Ok(())
@@ -1771,12 +1749,7 @@ impl PolyDatabase {
         let mut key_val = unsafe { crate::into_val(&key_bytes) };
 
         let result = unsafe {
-            mdb_result(ffi::mdb_del(
-                txn.txn.txn,
-                self.dbi,
-                &mut key_val,
-                ptr::null_mut(),
-            ))
+            mdb_result(ffi::mdb_del(txn.txn.txn, self.dbi, &mut key_val, ptr::null_mut()))
         };
 
         match result {

--- a/heed/src/db/uniform.rs
+++ b/heed/src/db/uniform.rs
@@ -121,10 +121,7 @@ pub struct Database<KC, DC> {
 
 impl<KC, DC> Database<KC, DC> {
     pub(crate) fn new(env_ident: usize, dbi: ffi::MDB_dbi) -> Database<KC, DC> {
-        Database {
-            dyndb: PolyDatabase::new(env_ident, dbi),
-            marker: std::marker::PhantomData,
-        }
+        Database { dyndb: PolyDatabase::new(env_ident, dbi), marker: std::marker::PhantomData }
     }
 
     /// Retrieve the sequence of a database.
@@ -412,8 +409,7 @@ impl<KC, DC> Database<KC, DC> {
         KC: BytesEncode<'a> + BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
     {
-        self.dyndb
-            .get_greater_than_or_equal_to::<T, KC, DC>(txn, key)
+        self.dyndb.get_greater_than_or_equal_to::<T, KC, DC>(txn, key)
     }
 
     /// Retrieves the first key/value pair of this database.
@@ -1603,10 +1599,7 @@ impl<KC, DC> Database<KC, DC> {
 
 impl<KC, DC> Clone for Database<KC, DC> {
     fn clone(&self) -> Database<KC, DC> {
-        Database {
-            dyndb: self.dyndb,
-            marker: marker::PhantomData,
-        }
+        Database { dyndb: self.dyndb, marker: marker::PhantomData }
     }
 }
 

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -277,10 +277,10 @@ pub enum CompactionOption {
 
 impl Env {
     /// Return the size used by all the databases in the environment.
-    pub fn size(&self) -> Result<usize> {
+    pub fn size(&self) -> Result<u64> {
         let compute_size = |stat: lmdb_sys::MDB_stat| {
-            (stat.ms_leaf_pages + stat.ms_branch_pages + stat.ms_overflow_pages)
-                * stat.ms_psize as usize
+            (stat.ms_leaf_pages + stat.ms_branch_pages + stat.ms_overflow_pages) as u64
+                * stat.ms_psize as u64
         };
 
         let mut size = 0;

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -1,15 +1,15 @@
 use std::any::TypeId;
 use std::collections::hash_map::{Entry, HashMap};
 use std::ffi::CString;
+#[cfg(windows)]
+use std::ffi::OsStr;
 use std::fs::File;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use std::{io, ptr, sync};
-#[cfg(windows)]
-use std::ffi::OsStr;
-#[cfg(unix)]
-use std::os::unix::ffi::OsStrExt;
 
 use once_cell::sync::Lazy;
 use synchronoise::event::SignalEvent;
@@ -17,8 +17,8 @@ use synchronoise::event::SignalEvent;
 use crate::cursor::RoCursor;
 use crate::flags::Flags;
 use crate::mdb::error::mdb_result;
-use crate::{Database, Error, PolyDatabase, Result, RoTxn, RwTxn};
 use crate::mdb::ffi;
+use crate::{Database, Error, PolyDatabase, Result, RoTxn, RwTxn};
 
 /// The list of opened environments, the value is an optional environment, it is None
 /// when someone asks to close the environment, closing is a two-phase step, to make sure
@@ -44,8 +44,10 @@ fn canonicalize_path(path: &Path) -> io::Result<PathBuf> {
 #[cfg(windows)]
 fn canonicalize_path(path: &Path) -> io::Result<PathBuf> {
     let canonical = path.canonicalize()?;
-    let url = url::Url::from_file_path(&canonical).map_err(|_e| io::Error::new(io::ErrorKind::Other, "URL passing error"))?;
-    url.to_file_path().map_err(|_e| io::Error::new(io::ErrorKind::Other, "path canonicalization error"))
+    let url = url::Url::from_file_path(&canonical)
+        .map_err(|_e| io::Error::new(io::ErrorKind::Other, "URL passing error"))?;
+    url.to_file_path()
+        .map_err(|_e| io::Error::new(io::ErrorKind::Other, "path canonicalization error"))
 }
 
 #[cfg(windows)]
@@ -83,12 +85,7 @@ pub struct EnvOpenOptions {
 
 impl EnvOpenOptions {
     pub fn new() -> EnvOpenOptions {
-        EnvOpenOptions {
-            map_size: None,
-            max_readers: None,
-            max_dbs: None,
-            flags: 0,
-        }
+        EnvOpenOptions { map_size: None, max_readers: None, max_dbs: None, flags: 0 }
     }
 
     pub fn map_size(&mut self, size: usize) -> &mut Self {
@@ -161,10 +158,10 @@ impl EnvOpenOptions {
         match lock.entry(path) {
             Entry::Occupied(entry) => {
                 if &entry.get().options != self {
-                    return Err(Error::BadOpenOptions)
+                    return Err(Error::BadOpenOptions);
                 }
                 entry.get().env.clone().ok_or(Error::DatabaseClosing)
-            },
+            }
             Entry::Vacant(entry) => {
                 let path = entry.key();
                 let path_str = CString::new(path.as_os_str().as_bytes()).unwrap();
@@ -177,9 +174,13 @@ impl EnvOpenOptions {
                         if size % page_size::get() != 0 {
                             let msg = format!(
                                 "map size ({}) must be a multiple of the system page size ({})",
-                                size, page_size::get()
+                                size,
+                                page_size::get()
                             );
-                            return Err(Error::Io(io::Error::new(io::ErrorKind::InvalidInput, msg)));
+                            return Err(Error::Io(io::Error::new(
+                                io::ErrorKind::InvalidInput,
+                                msg,
+                            )));
                         }
                         mdb_result(ffi::mdb_env_set_mapsize(env, size))?;
                     }
@@ -201,12 +202,8 @@ impl EnvOpenOptions {
                         self.flags
                     };
 
-                    let result = mdb_result(ffi::mdb_env_open(
-                        env,
-                        path_str.as_ptr(),
-                        flags,
-                        0o600,
-                    ));
+                    let result =
+                        mdb_result(ffi::mdb_env_open(env, path_str.as_ptr(), flags, 0o600));
 
                     match result {
                         Ok(()) => {
@@ -262,7 +259,9 @@ impl Drop for EnvInner {
         match lock.remove(&self.path) {
             None => panic!("It seems another env closed this env before"),
             Some(EnvEntry { signal_event, .. }) => {
-                unsafe { let _ = ffi::mdb_env_close(self.env); }
+                unsafe {
+                    let _ = ffi::mdb_env_close(self.env);
+                }
                 // We signal to all the waiters that we have closed the env.
                 signal_event.signal();
             }
@@ -294,10 +293,7 @@ impl Env {
 
         // we don’t want anyone to open an environment while we’re computing the stats
         // thus we take a lock on all mutexes
-        let locks = (
-            OPENED_ENV.write().unwrap(),
-            self.0.dbi_open_mutex.lock().unwrap(),
-        );
+        let locks = (OPENED_ENV.write().unwrap(), self.0.dbi_open_mutex.lock().unwrap());
 
         // We’re going to iterate on the unnamed database
         let mut cursor = RoCursor::new(&rtxn, dbi)?;
@@ -344,8 +340,9 @@ impl Env {
     }
 
     pub fn open_poly_database(&self, name: Option<&str>) -> Result<Option<PolyDatabase>> {
-        Ok(self.raw_open_database(name, None)?
-                .map(|db| PolyDatabase::new(self.env_mut_ptr() as _, db)))
+        Ok(self
+            .raw_open_database(name, None)?
+            .map(|db| PolyDatabase::new(self.env_mut_ptr() as _, db)))
     }
 
     fn raw_open_dbi(
@@ -452,12 +449,7 @@ impl Env {
         let mut lock = self.0.dbi_open_mutex.lock().unwrap();
 
         let result = unsafe {
-            mdb_result(ffi::mdb_dbi_open(
-                wtxn.txn.txn,
-                name_ptr,
-                ffi::MDB_CREATE,
-                &mut dbi,
-            ))
+            mdb_result(ffi::mdb_dbi_open(wtxn.txn.txn, name_ptr, ffi::MDB_CREATE, &mut dbi))
         };
 
         drop(name);
@@ -486,7 +478,10 @@ impl Env {
         RwTxn::<T>::new(self)
     }
 
-    pub fn nested_write_txn<'e, 'p: 'e, T>(&'e self, parent: &'p mut RwTxn<T>) -> Result<RwTxn<'e, 'p, T>> {
+    pub fn nested_write_txn<'e, 'p: 'e, T>(
+        &'e self,
+        parent: &'p mut RwTxn<T>,
+    ) -> Result<RwTxn<'e, 'p, T>> {
         RwTxn::nested(self, parent)
     }
 
@@ -503,7 +498,9 @@ impl Env {
         let file = File::options().create_new(true).write(true).open(&path)?;
         let fd = get_file_fd(&file);
 
-        unsafe { self.copy_to_fd(fd, option)?; }
+        unsafe {
+            self.copy_to_fd(fd, option)?;
+        }
 
         // We reopen the file to make sure the cursor is at the start,
         // even a seek to start doesn't work properly.
@@ -512,7 +509,11 @@ impl Env {
         Ok(file)
     }
 
-    pub unsafe fn copy_to_fd(&self, fd: ffi::mdb_filehandle_t, option: CompactionOption) -> Result<()> {
+    pub unsafe fn copy_to_fd(
+        &self,
+        fd: ffi::mdb_filehandle_t,
+        option: CompactionOption,
+    ) -> Result<()> {
         let flags = if let CompactionOption::Enabled = option { ffi::MDB_CP_COMPACT } else { 0 };
 
         mdb_result(ffi::mdb_env_copy2fd(self.0.env, fd, flags))?;
@@ -595,8 +596,8 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use crate::{types::*, EnvOpenOptions};
-    use crate::env_closing_event;
+    use crate::types::*;
+    use crate::{env_closing_event, EnvOpenOptions};
 
     #[test]
     fn close_env() {
@@ -605,7 +606,8 @@ mod tests {
         let env = EnvOpenOptions::new()
             .map_size(10 * 1024 * 1024) // 10MB
             .max_dbs(30)
-            .open(&path).unwrap();
+            .open(&path)
+            .unwrap();
 
         // Force a thread to keep the env for 1 second.
         let env_cloned = env.clone();
@@ -646,7 +648,8 @@ mod tests {
         let path = dir.path();
         let _env = EnvOpenOptions::new()
             .map_size(10 * 1024 * 1024) // 10MB
-            .open(&path).unwrap();
+            .open(&path)
+            .unwrap();
 
         let env = EnvOpenOptions::new()
             .map_size(12 * 1024 * 1024) // 10MB

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -276,8 +276,8 @@ pub enum CompactionOption {
 }
 
 impl Env {
-    /// Return the size used by all the databases in the environment.
-    pub fn size(&self) -> Result<u64> {
+    /// Returns the size used by all the databases on the disk in the environment without taking the free pages into account.
+    pub fn real_disk_space_size(&self) -> Result<u64> {
         let compute_size = |stat: lmdb_sys::MDB_stat| {
             (stat.ms_leaf_pages + stat.ms_branch_pages + stat.ms_overflow_pages) as u64
                 * stat.ms_psize as u64

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -282,7 +282,7 @@ impl Env {
         let mut size = 0;
 
         let mut stat = std::mem::MaybeUninit::uninit();
-        unsafe { mdb_result(ffi::mdb_env_stat(self.0.env, stat.as_mut_ptr())) }?;
+        unsafe { mdb_result(ffi::mdb_env_stat(self.0.env, stat.as_mut_ptr()))? };
         let stat = unsafe { stat.assume_init() };
 
         size += (stat.ms_leaf_pages + stat.ms_branch_pages + stat.ms_overflow_pages)

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -292,8 +292,8 @@ impl Env {
         let dbi = self.raw_open_dbi(&rtxn, None, 0)?;
 
         // we don’t want anyone to open an environment while we’re computing the stats
-        // thus we take a lock on all mutexes
-        let locks = (OPENED_ENV.write().unwrap(), self.0.dbi_open_mutex.lock().unwrap());
+        // thus we take a lock on the dbi
+        let _lock = self.0.dbi_open_mutex.lock().unwrap();
 
         // We’re going to iterate on the unnamed database
         let mut cursor = RoCursor::new(&rtxn, dbi)?;
@@ -317,9 +317,6 @@ impl Env {
             size += (stat.ms_leaf_pages + stat.ms_branch_pages + stat.ms_overflow_pages)
                 * stat.ms_psize as usize;
         }
-
-        // once we reach this point we don’t need the lock anymore
-        drop(locks);
 
         Ok(size)
     }

--- a/heed/src/iter/iter.rs
+++ b/heed/src/iter/iter.rs
@@ -1,6 +1,7 @@
-use crate::*;
 use std::borrow::Cow;
 use std::marker;
+
+use crate::*;
 
 pub struct RoIter<'txn, KC, DC> {
     cursor: RoCursor<'txn>,
@@ -10,11 +11,7 @@ pub struct RoIter<'txn, KC, DC> {
 
 impl<'txn, KC, DC> RoIter<'txn, KC, DC> {
     pub(crate) fn new(cursor: RoCursor<'txn>) -> RoIter<'txn, KC, DC> {
-        RoIter {
-            cursor,
-            move_on_first: true,
-            _phantom: marker::PhantomData,
-        }
+        RoIter { cursor, move_on_first: true, _phantom: marker::PhantomData }
     }
 
     /// Change the codec types of this iterator, specifying the codecs.
@@ -99,11 +96,7 @@ pub struct RwIter<'txn, KC, DC> {
 
 impl<'txn, KC, DC> RwIter<'txn, KC, DC> {
     pub(crate) fn new(cursor: RwCursor<'txn>) -> RwIter<'txn, KC, DC> {
-        RwIter {
-            cursor,
-            move_on_first: true,
-            _phantom: marker::PhantomData,
-        }
+        RwIter { cursor, move_on_first: true, _phantom: marker::PhantomData }
     }
 
     /// Delete the entry the cursor is currently pointing to.
@@ -270,11 +263,7 @@ pub struct RoRevIter<'txn, KC, DC> {
 
 impl<'txn, KC, DC> RoRevIter<'txn, KC, DC> {
     pub(crate) fn new(cursor: RoCursor<'txn>) -> RoRevIter<'txn, KC, DC> {
-        RoRevIter {
-            cursor,
-            move_on_last: true,
-            _phantom: marker::PhantomData,
-        }
+        RoRevIter { cursor, move_on_last: true, _phantom: marker::PhantomData }
     }
 
     /// Change the codec types of this iterator, specifying the codecs.
@@ -359,11 +348,7 @@ pub struct RwRevIter<'txn, KC, DC> {
 
 impl<'txn, KC, DC> RwRevIter<'txn, KC, DC> {
     pub(crate) fn new(cursor: RwCursor<'txn>) -> RwRevIter<'txn, KC, DC> {
-        RwRevIter {
-            cursor,
-            move_on_last: true,
-            _phantom: marker::PhantomData,
-        }
+        RwRevIter { cursor, move_on_last: true, _phantom: marker::PhantomData }
     }
 
     /// Delete the entry the cursor is currently pointing to.

--- a/heed/src/iter/mod.rs
+++ b/heed/src/iter/mod.rs
@@ -1,10 +1,10 @@
 mod iter;
-mod range;
 mod prefix;
+mod range;
 
 pub use self::iter::{RoIter, RoRevIter, RwIter, RwRevIter};
-pub use self::range::{RoRange, RoRevRange, RwRange, RwRevRange};
 pub use self::prefix::{RoPrefix, RoRevPrefix, RwPrefix, RwRevPrefix};
+pub use self::range::{RoRange, RoRevRange, RwRange, RwRevRange};
 
 fn advance_key(bytes: &mut Vec<u8>) {
     match bytes.last_mut() {
@@ -15,7 +15,9 @@ fn advance_key(bytes: &mut Vec<u8>) {
 
 fn retreat_key(bytes: &mut Vec<u8>) {
     match bytes.last_mut() {
-        Some(&mut 0) => { bytes.pop(); },
+        Some(&mut 0) => {
+            bytes.pop();
+        }
         Some(last) => *last -= 1,
         None => panic!("Vec is empty and must not be"),
     }
@@ -27,14 +29,16 @@ mod tests {
     fn prefix_iter_with_byte_255() {
         use std::fs;
         use std::path::Path;
-        use crate::EnvOpenOptions;
+
         use crate::types::*;
+        use crate::EnvOpenOptions;
 
         fs::create_dir_all(Path::new("target").join("prefix_iter_with_byte_255.mdb")).unwrap();
         let env = EnvOpenOptions::new()
             .map_size(10 * 1024 * 1024) // 10MB
             .max_dbs(3000)
-            .open(Path::new("target").join("prefix_iter_with_byte_255.mdb")).unwrap();
+            .open(Path::new("target").join("prefix_iter_with_byte_255.mdb"))
+            .unwrap();
         let db = env.create_database::<ByteSlice, Str>(None).unwrap();
 
         // Create an ordered list of keys...
@@ -42,12 +46,18 @@ mod tests {
         db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], "world").unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], "hello").unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], "world").unwrap();
-        db.put(&mut wtxn, &[0, 0, 1,   0, 119, 111, 114, 108, 100], "world").unwrap();
+        db.put(&mut wtxn, &[0, 0, 1, 0, 119, 111, 114, 108, 100], "world").unwrap();
 
         // Lets check that we can prefix_iter on that sequence with the key "255".
         let mut iter = db.prefix_iter(&wtxn, &[0, 0, 0, 255]).unwrap();
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[0u8, 0, 0, 255, 104, 101, 108, 108, 111][..], "hello")));
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[  0, 0, 0, 255, 119, 111, 114, 108, 100][..], "world")));
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0u8, 0, 0, 255, 104, 101, 108, 108, 111][..], "hello"))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], "world"))
+        );
         assert_eq!(iter.next().transpose().unwrap(), None);
         drop(iter);
 
@@ -58,15 +68,18 @@ mod tests {
     fn iter_last() {
         use std::fs;
         use std::path::Path;
-        use crate::EnvOpenOptions;
+
+        use crate::byteorder::BigEndian;
         use crate::types::*;
-        use crate::{zerocopy::I32, byteorder::BigEndian};
+        use crate::zerocopy::I32;
+        use crate::EnvOpenOptions;
 
         fs::create_dir_all(Path::new("target").join("iter_last.mdb")).unwrap();
         let env = EnvOpenOptions::new()
             .map_size(10 * 1024 * 1024) // 10MB
             .max_dbs(3000)
-            .open(Path::new("target").join("iter_last.mdb")).unwrap();
+            .open(Path::new("target").join("iter_last.mdb"))
+            .unwrap();
         let db = env.create_database::<OwnedType<BEI32>, Unit>(None).unwrap();
         type BEI32 = I32<BigEndian>;
 
@@ -123,15 +136,18 @@ mod tests {
     fn range_iter_last() {
         use std::fs;
         use std::path::Path;
-        use crate::EnvOpenOptions;
-        use crate::{zerocopy::I32, byteorder::BigEndian};
+
+        use crate::byteorder::BigEndian;
         use crate::types::*;
+        use crate::zerocopy::I32;
+        use crate::EnvOpenOptions;
 
         fs::create_dir_all(Path::new("target").join("iter_last.mdb")).unwrap();
         let env = EnvOpenOptions::new()
             .map_size(10 * 1024 * 1024) // 10MB
             .max_dbs(3000)
-            .open(Path::new("target").join("iter_last.mdb")).unwrap();
+            .open(Path::new("target").join("iter_last.mdb"))
+            .unwrap();
         let db = env.create_database::<OwnedType<BEI32>, Unit>(None).unwrap();
         type BEI32 = I32<BigEndian>;
 
@@ -212,14 +228,16 @@ mod tests {
     fn prefix_iter_last() {
         use std::fs;
         use std::path::Path;
-        use crate::EnvOpenOptions;
+
         use crate::types::*;
+        use crate::EnvOpenOptions;
 
         fs::create_dir_all(Path::new("target").join("prefix_iter_last.mdb")).unwrap();
         let env = EnvOpenOptions::new()
             .map_size(10 * 1024 * 1024) // 10MB
             .max_dbs(3000)
-            .open(Path::new("target").join("prefix_iter_last.mdb")).unwrap();
+            .open(Path::new("target").join("prefix_iter_last.mdb"))
+            .unwrap();
         let db = env.create_database::<ByteSlice, Unit>(None).unwrap();
 
         // Create an ordered list of keys...
@@ -227,28 +245,55 @@ mod tests {
         db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], &()).unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], &()).unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 1,   0, 119, 111, 114, 108, 100], &()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 1, 0, 119, 111, 114, 108, 100], &()).unwrap();
 
         // Lets check that we properly get the last entry.
         let iter = db.prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
-        assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ())));
+        assert_eq!(
+            iter.last().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ()))
+        );
 
         let mut iter = db.prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ())));
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ())));
-        assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ())));
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ()))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ()))
+        );
+        assert_eq!(
+            iter.last().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ()))
+        );
 
         let mut iter = db.prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ())));
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ())));
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ())));
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ()))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ()))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ()))
+        );
         assert_eq!(iter.last().transpose().unwrap(), None);
 
         let iter = db.prefix_iter(&wtxn, &[0, 0, 1]).unwrap();
-        assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 1,   0, 119, 111, 114, 108, 100][..], ())));
+        assert_eq!(
+            iter.last().transpose().unwrap(),
+            Some((&[0, 0, 1, 0, 119, 111, 114, 108, 100][..], ()))
+        );
 
         let mut iter = db.prefix_iter(&wtxn, &[0, 0, 1]).unwrap();
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 1,   0, 119, 111, 114, 108, 100][..], ())));
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 1, 0, 119, 111, 114, 108, 100][..], ()))
+        );
         assert_eq!(iter.last().transpose().unwrap(), None);
 
         wtxn.abort().unwrap();
@@ -258,14 +303,16 @@ mod tests {
     fn rev_prefix_iter_last() {
         use std::fs;
         use std::path::Path;
-        use crate::EnvOpenOptions;
+
         use crate::types::*;
+        use crate::EnvOpenOptions;
 
         fs::create_dir_all(Path::new("target").join("prefix_iter_last.mdb")).unwrap();
         let env = EnvOpenOptions::new()
             .map_size(10 * 1024 * 1024) // 10MB
             .max_dbs(3000)
-            .open(Path::new("target").join("prefix_iter_last.mdb")).unwrap();
+            .open(Path::new("target").join("prefix_iter_last.mdb"))
+            .unwrap();
         let db = env.create_database::<ByteSlice, Unit>(None).unwrap();
 
         // Create an ordered list of keys...
@@ -273,28 +320,55 @@ mod tests {
         db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], &()).unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], &()).unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], &()).unwrap();
-        db.put(&mut wtxn, &[0, 0, 1,   0, 119, 111, 114, 108, 100], &()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 1, 0, 119, 111, 114, 108, 100], &()).unwrap();
 
         // Lets check that we properly get the last entry.
         let iter = db.rev_prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
-        assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ())));
+        assert_eq!(
+            iter.last().transpose().unwrap(),
+            Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ()))
+        );
 
         let mut iter = db.rev_prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ())));
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ())));
-        assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ())));
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ()))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ()))
+        );
+        assert_eq!(
+            iter.last().transpose().unwrap(),
+            Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ()))
+        );
 
         let mut iter = db.rev_prefix_iter(&wtxn, &[0, 0, 0]).unwrap();
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ())));
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ())));
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ())));
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ()))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ()))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 0, 254, 119, 111, 114, 108, 100][..], ()))
+        );
         assert_eq!(iter.last().transpose().unwrap(), None);
 
         let iter = db.rev_prefix_iter(&wtxn, &[0, 0, 1]).unwrap();
-        assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 1,   0, 119, 111, 114, 108, 100][..], ())));
+        assert_eq!(
+            iter.last().transpose().unwrap(),
+            Some((&[0, 0, 1, 0, 119, 111, 114, 108, 100][..], ()))
+        );
 
         let mut iter = db.rev_prefix_iter(&wtxn, &[0, 0, 1]).unwrap();
-        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 1,   0, 119, 111, 114, 108, 100][..], ())));
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 1, 0, 119, 111, 114, 108, 100][..], ()))
+        );
         assert_eq!(iter.last().transpose().unwrap(), None);
 
         wtxn.abort().unwrap();
@@ -304,15 +378,18 @@ mod tests {
     fn rev_range_iter_last() {
         use std::fs;
         use std::path::Path;
-        use crate::EnvOpenOptions;
-        use crate::{zerocopy::I32, byteorder::BigEndian};
+
+        use crate::byteorder::BigEndian;
         use crate::types::*;
+        use crate::zerocopy::I32;
+        use crate::EnvOpenOptions;
 
         fs::create_dir_all(Path::new("target").join("range_iter_last.mdb")).unwrap();
         let env = EnvOpenOptions::new()
             .map_size(10 * 1024 * 1024) // 10MB
             .max_dbs(3000)
-            .open(Path::new("target").join("range_iter_last.mdb")).unwrap();
+            .open(Path::new("target").join("range_iter_last.mdb"))
+            .unwrap();
         let db = env.create_database::<OwnedType<BEI32>, Unit>(None).unwrap();
         type BEI32 = I32<BigEndian>;
 

--- a/heed/src/iter/prefix.rs
+++ b/heed/src/iter/prefix.rs
@@ -9,9 +9,8 @@ fn move_on_prefix_end<'txn>(
     prefix: &mut Vec<u8>,
 ) -> Result<Option<(&'txn [u8], &'txn [u8])>> {
     advance_key(prefix);
-    let result = cursor
-        .move_on_key_greater_than_or_equal_to(prefix)
-        .and_then(|_| cursor.move_on_prev());
+    let result =
+        cursor.move_on_key_greater_than_or_equal_to(prefix).and_then(|_| cursor.move_on_prev());
     retreat_key(prefix);
     result
 }
@@ -25,12 +24,7 @@ pub struct RoPrefix<'txn, KC, DC> {
 
 impl<'txn, KC, DC> RoPrefix<'txn, KC, DC> {
     pub(crate) fn new(cursor: RoCursor<'txn>, prefix: Vec<u8>) -> RoPrefix<'txn, KC, DC> {
-        RoPrefix {
-            cursor,
-            prefix,
-            move_on_first: true,
-            _phantom: marker::PhantomData,
-        }
+        RoPrefix { cursor, prefix, move_on_first: true, _phantom: marker::PhantomData }
     }
 
     /// Change the codec types of this iterator, specifying the codecs.
@@ -69,8 +63,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         let result = if self.move_on_first {
             self.move_on_first = false;
-            self.cursor
-                .move_on_key_greater_than_or_equal_to(&self.prefix)
+            self.cursor.move_on_key_greater_than_or_equal_to(&self.prefix)
         } else {
             self.cursor.move_on_next()
         };
@@ -95,10 +88,7 @@ where
         let result = if self.move_on_first {
             move_on_prefix_end(&mut self.cursor, &mut self.prefix)
         } else {
-            match (
-                self.cursor.current(),
-                move_on_prefix_end(&mut self.cursor, &mut self.prefix),
-            ) {
+            match (self.cursor.current(), move_on_prefix_end(&mut self.cursor, &mut self.prefix)) {
                 (Ok(Some((ckey, _))), Ok(Some((key, data)))) if ckey != key => {
                     Ok(Some((key, data)))
                 }
@@ -133,12 +123,7 @@ pub struct RwPrefix<'txn, KC, DC> {
 
 impl<'txn, KC, DC> RwPrefix<'txn, KC, DC> {
     pub(crate) fn new(cursor: RwCursor<'txn>, prefix: Vec<u8>) -> RwPrefix<'txn, KC, DC> {
-        RwPrefix {
-            cursor,
-            prefix,
-            move_on_first: true,
-            _phantom: marker::PhantomData,
-        }
+        RwPrefix { cursor, prefix, move_on_first: true, _phantom: marker::PhantomData }
     }
 
     /// Delete the entry the cursor is currently pointing to.
@@ -259,8 +244,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         let result = if self.move_on_first {
             self.move_on_first = false;
-            self.cursor
-                .move_on_key_greater_than_or_equal_to(&self.prefix)
+            self.cursor.move_on_key_greater_than_or_equal_to(&self.prefix)
         } else {
             self.cursor.move_on_next()
         };
@@ -285,10 +269,7 @@ where
         let result = if self.move_on_first {
             move_on_prefix_end(&mut self.cursor, &mut self.prefix)
         } else {
-            match (
-                self.cursor.current(),
-                move_on_prefix_end(&mut self.cursor, &mut self.prefix),
-            ) {
+            match (self.cursor.current(), move_on_prefix_end(&mut self.cursor, &mut self.prefix)) {
                 (Ok(Some((ckey, _))), Ok(Some((key, data)))) if ckey != key => {
                     Ok(Some((key, data)))
                 }
@@ -323,12 +304,7 @@ pub struct RoRevPrefix<'txn, KC, DC> {
 
 impl<'txn, KC, DC> RoRevPrefix<'txn, KC, DC> {
     pub(crate) fn new(cursor: RoCursor<'txn>, prefix: Vec<u8>) -> RoRevPrefix<'txn, KC, DC> {
-        RoRevPrefix {
-            cursor,
-            prefix,
-            move_on_last: true,
-            _phantom: marker::PhantomData,
-        }
+        RoRevPrefix { cursor, prefix, move_on_last: true, _phantom: marker::PhantomData }
     }
 
     /// Change the codec types of this iterator, specifying the codecs.
@@ -390,13 +366,10 @@ where
 
     fn last(mut self) -> Option<Self::Item> {
         let result = if self.move_on_last {
-            self.cursor
-                .move_on_key_greater_than_or_equal_to(&self.prefix)
+            self.cursor.move_on_key_greater_than_or_equal_to(&self.prefix)
         } else {
             let current = self.cursor.current();
-            let start = self
-                .cursor
-                .move_on_key_greater_than_or_equal_to(&self.prefix);
+            let start = self.cursor.move_on_key_greater_than_or_equal_to(&self.prefix);
             match (current, start) {
                 (Ok(Some((ckey, _))), Ok(Some((key, data)))) if ckey != key => {
                     Ok(Some((key, data)))
@@ -432,12 +405,7 @@ pub struct RwRevPrefix<'txn, KC, DC> {
 
 impl<'txn, KC, DC> RwRevPrefix<'txn, KC, DC> {
     pub(crate) fn new(cursor: RwCursor<'txn>, prefix: Vec<u8>) -> RwRevPrefix<'txn, KC, DC> {
-        RwRevPrefix {
-            cursor,
-            prefix,
-            move_on_last: true,
-            _phantom: marker::PhantomData,
-        }
+        RwRevPrefix { cursor, prefix, move_on_last: true, _phantom: marker::PhantomData }
     }
 
     /// Delete the entry the cursor is currently pointing to.
@@ -581,13 +549,10 @@ where
 
     fn last(mut self) -> Option<Self::Item> {
         let result = if self.move_on_last {
-            self.cursor
-                .move_on_key_greater_than_or_equal_to(&self.prefix)
+            self.cursor.move_on_key_greater_than_or_equal_to(&self.prefix)
         } else {
             let current = self.cursor.current();
-            let start = self
-                .cursor
-                .move_on_key_greater_than_or_equal_to(&self.prefix);
+            let start = self.cursor.move_on_key_greater_than_or_equal_to(&self.prefix);
             match (current, start) {
                 (Ok(Some((ckey, _))), Ok(Some((key, data)))) if ckey != key => {
                     Ok(Some((key, data)))

--- a/heed/src/iter/range.rs
+++ b/heed/src/iter/range.rs
@@ -15,9 +15,9 @@ fn move_on_range_end<'txn>(
             Ok(_) => cursor.move_on_prev(),
             Err(e) => Err(e),
         },
-        Bound::Excluded(end) => cursor
-            .move_on_key_greater_than_or_equal_to(end)
-            .and_then(|_| cursor.move_on_prev()),
+        Bound::Excluded(end) => {
+            cursor.move_on_key_greater_than_or_equal_to(end).and_then(|_| cursor.move_on_prev())
+        }
         Bound::Unbounded => cursor.move_on_last(),
     }
 }
@@ -129,10 +129,7 @@ where
         let result = if self.move_on_start {
             move_on_range_end(&mut self.cursor, &self.end_bound)
         } else {
-            match (
-                self.cursor.current(),
-                move_on_range_end(&mut self.cursor, &self.end_bound),
-            ) {
+            match (self.cursor.current(), move_on_range_end(&mut self.cursor, &self.end_bound)) {
                 (Ok(Some((ckey, _))), Ok(Some((key, data)))) if ckey != key => {
                     Ok(Some((key, data)))
                 }
@@ -337,10 +334,7 @@ where
         let result = if self.move_on_start {
             move_on_range_end(&mut self.cursor, &self.end_bound)
         } else {
-            match (
-                self.cursor.current(),
-                move_on_range_end(&mut self.cursor, &self.end_bound),
-            ) {
+            match (self.cursor.current(), move_on_range_end(&mut self.cursor, &self.end_bound)) {
                 (Ok(Some((ckey, _))), Ok(Some((key, data)))) if ckey != key => {
                     Ok(Some((key, data)))
                 }

--- a/heed/src/lazy_decode.rs
+++ b/heed/src/lazy_decode.rs
@@ -1,5 +1,6 @@
 use std::marker;
-use crate::{Result, Error};
+
+use crate::{Error, Result};
 
 /// Lazily decode the data bytes, it can be used to avoid CPU intensive decoding
 /// before making sure we really need to decode it (e.g. based on the key).

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -55,25 +55,24 @@ mod lazy_decode;
 mod mdb;
 mod txn;
 
-pub use byteorder;
-pub use heed_types as types;
-pub use zerocopy;
-use heed_traits as traits;
+use std::{error, fmt, io, result};
 
+use heed_traits as traits;
+pub use {byteorder, heed_types as types, zerocopy};
+
+use self::cursor::{RoCursor, RwCursor};
 pub use self::db::{Database, PolyDatabase};
-pub use self::env::{CompactionOption, Env, EnvOpenOptions, env_closing_event, EnvClosingEvent};
-pub use self::iter::{RoIter, RoRevIter, RwIter, RwRevIter};
-pub use self::iter::{RoPrefix, RoRevPrefix, RwPrefix, RwRevPrefix};
-pub use self::iter::{RoRange, RoRevRange, RwRange, RwRevRange};
-pub use self::lazy_decode::{LazyDecode, Lazy};
+pub use self::env::{env_closing_event, CompactionOption, Env, EnvClosingEvent, EnvOpenOptions};
+pub use self::iter::{
+    RoIter, RoPrefix, RoRange, RoRevIter, RoRevPrefix, RoRevRange, RwIter, RwPrefix, RwRange,
+    RwRevIter, RwRevPrefix, RwRevRange,
+};
+pub use self::lazy_decode::{Lazy, LazyDecode};
 pub use self::mdb::error::Error as MdbError;
+use self::mdb::ffi::{from_val, into_val};
 pub use self::mdb::flags;
 pub use self::traits::{BytesDecode, BytesEncode};
 pub use self::txn::{RoTxn, RwTxn};
-use self::cursor::{RoCursor, RwCursor};
-use self::mdb::ffi::{into_val, from_val};
-
-use std::{error, fmt, io, result};
 
 /// An error that encapsulates all possible errors in this crate.
 #[derive(Debug)]
@@ -96,11 +95,13 @@ impl fmt::Display for Error {
             Error::Decoding => f.write_str("error while decoding"),
             Error::InvalidDatabaseTyping => {
                 f.write_str("database was previously opened with different types")
-            },
+            }
             Error::DatabaseClosing => {
                 f.write_str("database is in a closing phase, you can't open it at the same time")
-            },
-            Error::BadOpenOptions => f.write_str("an environment is already opened with different options"),
+            }
+            Error::BadOpenOptions => {
+                f.write_str("an environment is already opened with different options")
+            }
         }
     }
 }

--- a/heed/src/mdb/lmdb_error.rs
+++ b/heed/src/mdb/lmdb_error.rs
@@ -147,9 +147,6 @@ mod test {
     #[test]
     fn test_description() {
         assert_eq!("Permission denied", Error::from_err_code(13).to_string());
-        assert_eq!(
-            "MDB_NOTFOUND: No matching key/data pair found",
-            Error::NotFound.to_string()
-        );
+        assert_eq!("MDB_NOTFOUND: No matching key/data pair found", Error::NotFound.to_string());
     }
 }

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -1,41 +1,46 @@
 use lmdb_sys as ffi;
 
-pub use ffi::MDB_cursor as MDB_cursor;
-pub use ffi::MDB_dbi as MDB_dbi;
-pub use ffi::MDB_env as MDB_env;
-pub use ffi::mdb_filehandle_t as mdb_filehandle_t;
-pub use ffi::MDB_txn as MDB_txn;
+pub use ffi::mdb_filehandle_t;
+pub use ffi::MDB_cursor;
+pub use ffi::MDB_dbi;
+pub use ffi::MDB_env;
+pub use ffi::MDB_envinfo;
+pub use ffi::MDB_stat;
+pub use ffi::MDB_txn;
 
-pub use ffi::MDB_APPEND as MDB_APPEND;
-pub use ffi::MDB_CP_COMPACT as MDB_CP_COMPACT;
-pub use ffi::MDB_CREATE as MDB_CREATE;
-pub use ffi::MDB_CURRENT as MDB_CURRENT;
-pub use ffi::MDB_RDONLY as MDB_RDONLY;
+pub use ffi::MDB_APPEND;
+pub use ffi::MDB_CP_COMPACT;
+pub use ffi::MDB_CREATE;
+pub use ffi::MDB_CURRENT;
+pub use ffi::MDB_RDONLY;
 
-pub use ffi::mdb_env_close as mdb_env_close;
+pub use ffi::mdb_env_close;
 pub use ffi::mdb_env_copyfd2 as mdb_env_copy2fd;
-pub use ffi::mdb_env_create as mdb_env_create;
-pub use ffi::mdb_env_open as mdb_env_open;
-pub use ffi::mdb_env_set_mapsize as mdb_env_set_mapsize;
-pub use ffi::mdb_env_set_maxdbs as mdb_env_set_maxdbs;
-pub use ffi::mdb_env_set_maxreaders as mdb_env_set_maxreaders;
-pub use ffi::mdb_env_sync as mdb_env_sync;
+pub use ffi::mdb_env_create;
+pub use ffi::mdb_env_info;
+pub use ffi::mdb_env_open;
+pub use ffi::mdb_env_set_mapsize;
+pub use ffi::mdb_env_set_maxdbs;
+pub use ffi::mdb_env_set_maxreaders;
+pub use ffi::mdb_env_stat;
+pub use ffi::mdb_env_sync;
 
-pub use ffi::mdb_dbi_open as mdb_dbi_open;
-pub use ffi::mdb_del as mdb_del;
-pub use ffi::mdb_drop as mdb_drop;
-pub use ffi::mdb_get as mdb_get;
-pub use ffi::mdb_put as mdb_put;
+pub use ffi::mdb_dbi_open;
+pub use ffi::mdb_del;
+pub use ffi::mdb_drop;
+pub use ffi::mdb_get;
+pub use ffi::mdb_put;
+pub use ffi::mdb_stat;
 
-pub use ffi::mdb_txn_abort as mdb_txn_abort;
-pub use ffi::mdb_txn_begin as mdb_txn_begin;
-pub use ffi::mdb_txn_commit as mdb_txn_commit;
+pub use ffi::mdb_txn_abort;
+pub use ffi::mdb_txn_begin;
+pub use ffi::mdb_txn_commit;
 
-pub use ffi::mdb_cursor_close as mdb_cursor_close;
-pub use ffi::mdb_cursor_del as mdb_cursor_del;
-pub use ffi::mdb_cursor_get as mdb_cursor_get;
-pub use ffi::mdb_cursor_open as mdb_cursor_open;
-pub use ffi::mdb_cursor_put as mdb_cursor_put;
+pub use ffi::mdb_cursor_close;
+pub use ffi::mdb_cursor_del;
+pub use ffi::mdb_cursor_get;
+pub use ffi::mdb_cursor_open;
+pub use ffi::mdb_cursor_put;
 
 pub mod cursor_op {
     use super::ffi::{self, MDB_cursor_op};

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -1,13 +1,48 @@
-pub use ffi::{
-    mdb_cursor_close, mdb_cursor_del, mdb_cursor_get, mdb_cursor_open, mdb_cursor_put,
-    mdb_dbi_open, mdb_del, mdb_drop, mdb_env_close, mdb_env_copyfd2 as mdb_env_copy2fd,
-    mdb_env_create, mdb_env_info, mdb_env_open, mdb_env_set_mapsize, mdb_env_set_maxdbs,
-    mdb_env_set_maxreaders, mdb_env_stat, mdb_env_sync, mdb_filehandle_t, mdb_get, mdb_put,
-    mdb_stat, mdb_txn_abort, mdb_txn_begin, mdb_txn_commit, MDB_cursor, MDB_dbi, MDB_env,
-    MDB_envinfo, MDB_stat, MDB_txn, MDB_APPEND, MDB_CP_COMPACT, MDB_CREATE, MDB_CURRENT,
-    MDB_RDONLY,
-};
 use lmdb_sys as ffi;
+
+#[rustfmt::skip]
+pub use ffi::{
+    mdb_filehandle_t,
+    MDB_cursor,
+    MDB_dbi,
+    MDB_env,
+    MDB_stat,
+    MDB_txn,
+
+    MDB_APPEND,
+    MDB_CP_COMPACT,
+    MDB_CREATE,
+    MDB_CURRENT,
+    MDB_RDONLY,
+
+    mdb_env_close,
+    mdb_env_copyfd2 as mdb_env_copy2fd,
+    mdb_env_create,
+    mdb_env_info,
+    mdb_env_open,
+    mdb_env_set_mapsize,
+    mdb_env_set_maxdbs,
+    mdb_env_set_maxreaders,
+    mdb_env_stat,
+    mdb_env_sync,
+
+    mdb_dbi_open,
+    mdb_del,
+    mdb_drop,
+    mdb_get,
+    mdb_put,
+    mdb_stat,
+
+    mdb_txn_abort,
+    mdb_txn_begin,
+    mdb_txn_commit,
+
+    mdb_cursor_close,
+    mdb_cursor_del,
+    mdb_cursor_get,
+    mdb_cursor_open,
+    mdb_cursor_put
+};
 
 pub mod cursor_op {
     use super::ffi::{self, MDB_cursor_op};

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -1,46 +1,13 @@
+pub use ffi::{
+    mdb_cursor_close, mdb_cursor_del, mdb_cursor_get, mdb_cursor_open, mdb_cursor_put,
+    mdb_dbi_open, mdb_del, mdb_drop, mdb_env_close, mdb_env_copyfd2 as mdb_env_copy2fd,
+    mdb_env_create, mdb_env_info, mdb_env_open, mdb_env_set_mapsize, mdb_env_set_maxdbs,
+    mdb_env_set_maxreaders, mdb_env_stat, mdb_env_sync, mdb_filehandle_t, mdb_get, mdb_put,
+    mdb_stat, mdb_txn_abort, mdb_txn_begin, mdb_txn_commit, MDB_cursor, MDB_dbi, MDB_env,
+    MDB_envinfo, MDB_stat, MDB_txn, MDB_APPEND, MDB_CP_COMPACT, MDB_CREATE, MDB_CURRENT,
+    MDB_RDONLY,
+};
 use lmdb_sys as ffi;
-
-pub use ffi::mdb_filehandle_t;
-pub use ffi::MDB_cursor;
-pub use ffi::MDB_dbi;
-pub use ffi::MDB_env;
-pub use ffi::MDB_envinfo;
-pub use ffi::MDB_stat;
-pub use ffi::MDB_txn;
-
-pub use ffi::MDB_APPEND;
-pub use ffi::MDB_CP_COMPACT;
-pub use ffi::MDB_CREATE;
-pub use ffi::MDB_CURRENT;
-pub use ffi::MDB_RDONLY;
-
-pub use ffi::mdb_env_close;
-pub use ffi::mdb_env_copyfd2 as mdb_env_copy2fd;
-pub use ffi::mdb_env_create;
-pub use ffi::mdb_env_info;
-pub use ffi::mdb_env_open;
-pub use ffi::mdb_env_set_mapsize;
-pub use ffi::mdb_env_set_maxdbs;
-pub use ffi::mdb_env_set_maxreaders;
-pub use ffi::mdb_env_stat;
-pub use ffi::mdb_env_sync;
-
-pub use ffi::mdb_dbi_open;
-pub use ffi::mdb_del;
-pub use ffi::mdb_drop;
-pub use ffi::mdb_get;
-pub use ffi::mdb_put;
-pub use ffi::mdb_stat;
-
-pub use ffi::mdb_txn_abort;
-pub use ffi::mdb_txn_begin;
-pub use ffi::mdb_txn_commit;
-
-pub use ffi::mdb_cursor_close;
-pub use ffi::mdb_cursor_del;
-pub use ffi::mdb_cursor_get;
-pub use ffi::mdb_cursor_open;
-pub use ffi::mdb_cursor_put;
 
 pub mod cursor_op {
     use super::ffi::{self, MDB_cursor_op};
@@ -54,10 +21,7 @@ pub mod cursor_op {
 }
 
 pub unsafe fn into_val(value: &[u8]) -> ffi::MDB_val {
-    ffi::MDB_val {
-        mv_data: value.as_ptr() as *mut libc::c_void,
-        mv_size: value.len(),
-    }
+    ffi::MDB_val { mv_data: value.as_ptr() as *mut libc::c_void, mv_size: value.len() }
 }
 
 pub unsafe fn from_val<'a>(value: ffi::MDB_val) -> &'a [u8] {

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -26,6 +26,7 @@ pub use ffi::{
     mdb_env_stat,
     mdb_env_sync,
 
+    mdb_dbi_close,
     mdb_dbi_open,
     mdb_del,
     mdb_drop,

--- a/heed/src/mdb/mdbx_error.rs
+++ b/heed/src/mdb/mdbx_error.rs
@@ -196,9 +196,6 @@ mod test {
     #[test]
     fn test_description() {
         assert_eq!("Permission denied", Error::from_err_code(13).to_string());
-        assert_eq!(
-            "MDBX_NOTFOUND: No matching key/data pair found",
-            Error::NotFound.to_string()
-        );
+        assert_eq!("MDBX_NOTFOUND: No matching key/data pair found", Error::NotFound.to_string());
     }
 }

--- a/heed/src/mdb/mdbx_ffi.rs
+++ b/heed/src/mdb/mdbx_ffi.rs
@@ -1,42 +1,19 @@
+pub use ffi::{
+    mdbx_cursor_close as mdb_cursor_close, mdbx_cursor_del as mdb_cursor_del,
+    mdbx_cursor_get as mdb_cursor_get, mdbx_cursor_open as mdb_cursor_open,
+    mdbx_cursor_put as mdb_cursor_put, mdbx_dbi_open as mdb_dbi_open, mdbx_dbi_sequence,
+    mdbx_del as mdb_del, mdbx_drop as mdb_drop, mdbx_env_close as mdb_env_close,
+    mdbx_env_copy2fd as mdb_env_copy2fd, mdbx_env_create as mdb_env_create,
+    mdbx_env_open as mdb_env_open, mdbx_env_set_mapsize as mdb_env_set_mapsize,
+    mdbx_env_set_maxdbs as mdb_env_set_maxdbs, mdbx_env_set_maxreaders as mdb_env_set_maxreaders,
+    mdbx_env_sync as mdb_env_sync, mdbx_filehandle_t as mdb_filehandle_t, mdbx_get as mdb_get,
+    mdbx_put as mdb_put, mdbx_txn_abort as mdb_txn_abort, mdbx_txn_begin as mdb_txn_begin,
+    mdbx_txn_commit as mdb_txn_commit, MDBX_cursor as MDB_cursor, MDBX_dbi as MDB_dbi,
+    MDBX_env as MDB_env, MDBX_txn as MDB_txn, MDBX_APPEND as MDB_APPEND,
+    MDBX_CP_COMPACT as MDB_CP_COMPACT, MDBX_CREATE as MDB_CREATE, MDBX_CURRENT as MDB_CURRENT,
+    MDBX_RDONLY as MDB_RDONLY,
+};
 use mdbx_sys as ffi;
-
-pub use ffi::MDBX_cursor as MDB_cursor;
-pub use ffi::MDBX_dbi as MDB_dbi;
-pub use ffi::MDBX_env as MDB_env;
-pub use ffi::mdbx_filehandle_t as mdb_filehandle_t;
-pub use ffi::MDBX_txn as MDB_txn;
-
-pub use ffi::MDBX_APPEND as MDB_APPEND;
-pub use ffi::MDBX_CP_COMPACT as MDB_CP_COMPACT;
-pub use ffi::MDBX_CREATE as MDB_CREATE;
-pub use ffi::MDBX_CURRENT as MDB_CURRENT;
-pub use ffi::MDBX_RDONLY as MDB_RDONLY;
-
-pub use ffi::mdbx_env_close as mdb_env_close;
-pub use ffi::mdbx_env_copy2fd as mdb_env_copy2fd;
-pub use ffi::mdbx_env_create as mdb_env_create;
-pub use ffi::mdbx_env_open as mdb_env_open;
-pub use ffi::mdbx_env_set_mapsize as mdb_env_set_mapsize;
-pub use ffi::mdbx_env_set_maxdbs as mdb_env_set_maxdbs;
-pub use ffi::mdbx_env_set_maxreaders as mdb_env_set_maxreaders;
-pub use ffi::mdbx_env_sync as mdb_env_sync;
-
-pub use ffi::mdbx_dbi_open as mdb_dbi_open;
-pub use ffi::mdbx_dbi_sequence;
-pub use ffi::mdbx_del as mdb_del;
-pub use ffi::mdbx_drop as mdb_drop;
-pub use ffi::mdbx_get as mdb_get;
-pub use ffi::mdbx_put as mdb_put;
-
-pub use ffi::mdbx_txn_abort as mdb_txn_abort;
-pub use ffi::mdbx_txn_begin as mdb_txn_begin;
-pub use ffi::mdbx_txn_commit as mdb_txn_commit;
-
-pub use ffi::mdbx_cursor_close as mdb_cursor_close;
-pub use ffi::mdbx_cursor_del as mdb_cursor_del;
-pub use ffi::mdbx_cursor_get as mdb_cursor_get;
-pub use ffi::mdbx_cursor_open as mdb_cursor_open;
-pub use ffi::mdbx_cursor_put as mdb_cursor_put;
 
 pub mod cursor_op {
     use super::ffi::MDBX_cursor_op;
@@ -50,10 +27,7 @@ pub mod cursor_op {
 }
 
 pub unsafe fn into_val(value: &[u8]) -> ffi::MDBX_val {
-    ffi::MDBX_val {
-        iov_base: value.as_ptr() as *mut libc::c_void,
-        iov_len: value.len(),
-    }
+    ffi::MDBX_val { iov_base: value.as_ptr() as *mut libc::c_void, iov_len: value.len() }
 }
 
 pub unsafe fn from_val<'a>(value: ffi::MDBX_val) -> &'a [u8] {

--- a/heed/src/mdb/mdbx_ffi.rs
+++ b/heed/src/mdb/mdbx_ffi.rs
@@ -1,19 +1,45 @@
-pub use ffi::{
-    mdbx_cursor_close as mdb_cursor_close, mdbx_cursor_del as mdb_cursor_del,
-    mdbx_cursor_get as mdb_cursor_get, mdbx_cursor_open as mdb_cursor_open,
-    mdbx_cursor_put as mdb_cursor_put, mdbx_dbi_open as mdb_dbi_open, mdbx_dbi_sequence,
-    mdbx_del as mdb_del, mdbx_drop as mdb_drop, mdbx_env_close as mdb_env_close,
-    mdbx_env_copy2fd as mdb_env_copy2fd, mdbx_env_create as mdb_env_create,
-    mdbx_env_open as mdb_env_open, mdbx_env_set_mapsize as mdb_env_set_mapsize,
-    mdbx_env_set_maxdbs as mdb_env_set_maxdbs, mdbx_env_set_maxreaders as mdb_env_set_maxreaders,
-    mdbx_env_sync as mdb_env_sync, mdbx_filehandle_t as mdb_filehandle_t, mdbx_get as mdb_get,
-    mdbx_put as mdb_put, mdbx_txn_abort as mdb_txn_abort, mdbx_txn_begin as mdb_txn_begin,
-    mdbx_txn_commit as mdb_txn_commit, MDBX_cursor as MDB_cursor, MDBX_dbi as MDB_dbi,
-    MDBX_env as MDB_env, MDBX_txn as MDB_txn, MDBX_APPEND as MDB_APPEND,
-    MDBX_CP_COMPACT as MDB_CP_COMPACT, MDBX_CREATE as MDB_CREATE, MDBX_CURRENT as MDB_CURRENT,
-    MDBX_RDONLY as MDB_RDONLY,
-};
 use mdbx_sys as ffi;
+
+#[rustfmt::skip]
+pub use ffi::{
+    MDBX_cursor as MDB_cursor,
+    MDBX_dbi as MDB_dbi,
+    MDBX_env as MDB_env,
+    mdbx_filehandle_t as mdb_filehandle_t,
+    MDBX_txn as MDB_txn,
+
+    MDBX_APPEND as MDB_APPEND,
+    MDBX_CP_COMPACT as MDB_CP_COMPACT,
+    MDBX_CREATE as MDB_CREATE,
+    MDBX_CURRENT as MDB_CURRENT,
+    MDBX_RDONLY as MDB_RDONLY,
+
+    mdbx_env_close as mdb_env_close,
+    mdbx_env_copy2fd as mdb_env_copy2fd,
+    mdbx_env_create as mdb_env_create,
+    mdbx_env_open as mdb_env_open,
+    mdbx_env_set_mapsize as mdb_env_set_mapsize,
+    mdbx_env_set_maxdbs as mdb_env_set_maxdbs,
+    mdbx_env_set_maxreaders as mdb_env_set_maxreaders,
+    mdbx_env_sync as mdb_env_sync,
+
+    mdbx_dbi_open as mdb_dbi_open,
+    mdbx_dbi_sequence,
+    mdbx_del as mdb_del,
+    mdbx_drop as mdb_drop,
+    mdbx_get as mdb_get,
+    mdbx_put as mdb_put,
+
+    mdbx_txn_abort as mdb_txn_abort,
+    mdbx_txn_begin as mdb_txn_begin,
+    mdbx_txn_commit as mdb_txn_commit,
+
+    mdbx_cursor_close as mdb_cursor_close,
+    mdbx_cursor_del as mdb_cursor_del,
+    mdbx_cursor_get as mdb_cursor_get,
+    mdbx_cursor_open as mdb_cursor_open,
+    mdbx_cursor_put as mdb_cursor_put,
+};
 
 pub mod cursor_op {
     use super::ffi::MDBX_cursor_op;


### PR DESCRIPTION
Sorry everything got reformated, I was able to select the hunks for the env file but not for the ffi file.
But basically, only `pub use ffi::mdb_env_stat;`, `pub use ffi::mdb_stat;` and `pub use ffi::MDB_stat;` were added