### PR TITLE
Add the POSIX semaphore feature from LMDB

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -32,12 +32,18 @@ url = "2.2.0"
 [features]
 # The `serde` feature makes some types serializable,
 # like the `EnvOpenOptions` struct.
-default = ["serde", "serde-bincode", "serde-json"]
+default = ["serde", "serde-bincode", "serde-json", "posix-sem"]
 
 # The NO_TLS flag is automatically set on Env opening and
 # RoTxn implements the Sync trait. This allow the user to reference
 # a read-only transaction from multiple threads at the same time.
 sync-read-txn = []
+
+# Whether to tell LMDB to use POSIX semaphores during compilation
+# (instead of System V semaphores).
+# POSIX semaphores are required for Apple's App Sandbox on iOS & macOS,
+# and are possibly faster and more appropriate for single-process use.
+posix-sem = ["lmdb-rkv-sys/posix-sem"]
 
 # Enable the serde en/decoders for bincode or serde_json
 serde-bincode = ["heed-types/serde", "heed-types/bincode"]

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -32,7 +32,7 @@ url = "2.2.0"
 [features]
 # The `serde` feature makes some types serializable,
 # like the `EnvOpenOptions` struct.
-default = ["serde", "serde-bincode", "serde-json", "posix-sem"]
+default = ["serde", "serde-bincode", "serde-json"]
 
 # The NO_TLS flag is automatically set on Env opening and
 # RoTxn implements the Sync trait. This allow the user to reference


### PR DESCRIPTION
Before looking at this PR, please see https://github.com/meilisearch/lmdb-rs/pull/13. It is required before this PR can be merged.

This PR adds LMDB's POSIX semaphore feature to heed. This change allows iOS and macOS builds to be compliant with Apple's App Sandbox (necessary for distribution in the App Store), in addition to possible speed improvements brought upon by the POSIX semaphores.

You could investigate using POSIX semaphores within milli/meilisearch as well for the possible speed improvements they bring, but that is outside the scope of this PR.