### PR TITLE
Add POSIX semaphores Cargo feature

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -47,6 +47,15 @@ sync-read-txn = []
 lmdb = ["lmdb-rkv-sys"]
 mdbx = ["mdbx-sys"]
 
+# Whether to tell LMDB to use POSIX semaphores during compilation
+# (instead of the default, which are System V semaphores).
+# POSIX semaphores are required for Apple's App Sandbox on iOS & macOS,
+# and are possibly faster and more appropriate for single-process use.
+# There are tradeoffs for both POSIX and SysV semaphores; which you
+# should look into before enabling this feature. Also, see here:
+# https://github.com/LMDB/lmdb/blob/3947014aed7ffe39a79991fa7fb5b234da47ad1a/libraries/liblmdb/lmdb.h#L46-L69
+posix-sem = ["lmdb-rkv-sys/posix-sem"]
+
 # Enable the serde en/decoders for bincode or serde_json
 serde-bincode = ["heed-types/serde", "heed-types/bincode"]
 serde-json = ["heed-types/serde", "heed-types/serde_json"]


### PR DESCRIPTION
Copied from #140:

> Before looking at this PR, please see https://github.com/meilisearch/lmdb-rs/pull/13. It is required before this PR can be merged.
> 
> This PR adds LMDB's POSIX semaphore feature to heed. This change allows iOS and macOS builds to be compliant with Apple's App Sandbox (necessary for distribution in the App Store), in addition to possible speed improvements brought upon by the POSIX semaphores.
> 
> You could investigate using POSIX semaphores within milli/meilisearch as well for the possible speed improvements they bring, but that is outside the scope of this PR.