### PR TITLE
Better support opening an environment with the `MdbNoSubDir` flag

### DIFF
--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -178,6 +178,8 @@ impl EnvOpenOptions {
 
     /// Open an environment that will be located at the specified path.
     pub fn open<P: AsRef<Path>>(&self, path: P) -> Result<Env> {
+        let mut lock = OPENED_ENV.write().unwrap();
+
         let path = match canonicalize_path(path.as_ref()) {
             Err(err) => {
                 if err.kind() == NotFound && self.flags & (Flags::MdbNoSubDir as u32) != 0 {
@@ -192,8 +194,6 @@ impl EnvOpenOptions {
             }
             Ok(path) => path,
         };
-
-        let mut lock = OPENED_ENV.write().unwrap();
 
         match lock.entry(path) {
             Entry::Occupied(entry) => {

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -812,6 +812,14 @@ mod tests {
     }
 
     #[test]
+    fn open_database_with_nosubdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut envbuilder = EnvOpenOptions::new();
+        unsafe { envbuilder.flag(crate::Flags::MdbNoSubDir) };
+        let _env = envbuilder.open(&dir.path().join("data.mdb")).unwrap();
+    }
+
+    #[test]
     fn create_database_without_commit() {
         let dir = tempfile::tempdir().unwrap();
         let env = EnvOpenOptions::new()


### PR DESCRIPTION
Fixes #145 by trying to canonicalize only the path without the file if the file doesn't exist yet.