### PR TITLE
Make the error returned by the BytesDecode/BytesEncode trait customizable

### DIFF
--- a/heed-traits/src/lib.rs
+++ b/heed-traits/src/lib.rs
@@ -1,19 +1,17 @@
 use std::borrow::Cow;
-use std::error::Error as StdError;
-
-/// A boxed `Send + Sync + 'static` error.
-pub type BoxedError = Box<dyn StdError + Send + Sync + 'static>;
 
 /// A trait that represents an encoding structure.
 pub trait BytesEncode<'a> {
     type EItem: ?Sized + 'a;
+    type Err;
 
-    fn bytes_encode(item: &'a Self::EItem) -> Result<Cow<'a, [u8]>, BoxedError>;
+    fn bytes_encode(item: &'a Self::EItem) -> Result<Cow<'a, [u8]>, Self::Err>;
 }
 
 /// A trait that represents a decoding structure.
 pub trait BytesDecode<'a> {
     type DItem: 'a;
+    type Err;
 
-    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError>;
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Self::Err>;
 }

--- a/heed-types/src/lib.rs
+++ b/heed-types/src/lib.rs
@@ -37,7 +37,7 @@ mod serde_bincode;
 #[cfg(feature = "serde-json")]
 mod serde_json;
 
-use heed_traits::BoxedError;
+use std::convert::Infallible;
 
 pub use self::cow_slice::CowSlice;
 pub use self::cow_type::CowType;
@@ -63,8 +63,9 @@ pub struct DecodeIgnore;
 
 impl heed_traits::BytesDecode<'_> for DecodeIgnore {
     type DItem = ();
+    type Err = Infallible;
 
-    fn bytes_decode(_bytes: &[u8]) -> Result<Self::DItem, BoxedError> {
+    fn bytes_decode(_bytes: &[u8]) -> Result<Self::DItem, Self::Err> {
         Ok(())
     }
 }

--- a/heed-types/src/owned_slice.rs
+++ b/heed-types/src/owned_slice.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use bytemuck::{try_cast_slice, AnyBitPattern, NoUninit};
-use heed_traits::{BoxedError, BytesDecode, BytesEncode};
+use bytemuck::{try_cast_slice, AnyBitPattern, NoUninit, PodCastError};
+use heed_traits::{BytesDecode, BytesEncode};
 
 use crate::CowSlice;
 
@@ -22,16 +22,18 @@ pub struct OwnedSlice<T>(std::marker::PhantomData<T>);
 
 impl<'a, T: NoUninit> BytesEncode<'a> for OwnedSlice<T> {
     type EItem = [T];
+    type Err = PodCastError;
 
-    fn bytes_encode(item: &'a Self::EItem) -> Result<Cow<[u8]>, BoxedError> {
-        try_cast_slice(item).map(Cow::Borrowed).map_err(Into::into)
+    fn bytes_encode(item: &'a Self::EItem) -> Result<Cow<[u8]>, Self::Err> {
+        try_cast_slice(item).map(Cow::Borrowed)
     }
 }
 
 impl<'a, T: AnyBitPattern + NoUninit> BytesDecode<'a> for OwnedSlice<T> {
     type DItem = Vec<T>;
+    type Err = PodCastError;
 
-    fn bytes_decode(bytes: &[u8]) -> Result<Self::DItem, BoxedError> {
+    fn bytes_decode(bytes: &[u8]) -> Result<Self::DItem, Self::Err> {
         CowSlice::<T>::bytes_decode(bytes).map(Cow::into_owned)
     }
 }

--- a/heed-types/src/serde_bincode.rs
+++ b/heed-types/src/serde_bincode.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use heed_traits::{BoxedError, BytesDecode, BytesEncode};
+use heed_traits::{BytesDecode, BytesEncode};
 use serde::{Deserialize, Serialize};
 
 /// Describes a type that is [`Serialize`]/[`Deserialize`] and uses `bincode` to do so.
@@ -13,9 +13,10 @@ where
     T: Serialize,
 {
     type EItem = T;
+    type Err = bincode::Error;
 
-    fn bytes_encode(item: &'a Self::EItem) -> Result<Cow<[u8]>, BoxedError> {
-        bincode::serialize(item).map(Cow::Owned).map_err(Into::into)
+    fn bytes_encode(item: &'a Self::EItem) -> Result<Cow<[u8]>, Self::Err> {
+        bincode::serialize(item).map(Cow::Owned)
     }
 }
 
@@ -24,9 +25,10 @@ where
     T: Deserialize<'a>,
 {
     type DItem = T;
+    type Err = bincode::Error;
 
-    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
-        bincode::deserialize(bytes).map_err(Into::into)
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Self::Err> {
+        bincode::deserialize(bytes)
     }
 }
 

--- a/heed-types/src/serde_json.rs
+++ b/heed-types/src/serde_json.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use heed_traits::{BoxedError, BytesDecode, BytesEncode};
+use heed_traits::{BytesDecode, BytesEncode};
 use serde::{Deserialize, Serialize};
 
 /// Describes a type that is [`Serialize`]/[`Deserialize`] and uses `serde_json` to do so.
@@ -13,8 +13,9 @@ where
     T: Serialize,
 {
     type EItem = T;
+    type Err = serde_json::Error;
 
-    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, BoxedError> {
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Self::Err> {
         serde_json::to_vec(item).map(Cow::Owned).map_err(Into::into)
     }
 }
@@ -24,9 +25,10 @@ where
     T: Deserialize<'a>,
 {
     type DItem = T;
+    type Err = serde_json::Error;
 
-    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
-        serde_json::from_slice(bytes).map_err(Into::into)
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Self::Err> {
+        serde_json::from_slice(bytes)
     }
 }
 

--- a/heed-types/src/str.rs
+++ b/heed-types/src/str.rs
@@ -1,22 +1,26 @@
 use std::borrow::Cow;
+use std::convert::Infallible;
+use std::str::Utf8Error;
 
-use heed_traits::{BoxedError, BytesDecode, BytesEncode};
+use heed_traits::{BytesDecode, BytesEncode};
 
 /// Describes an [`prim@str`].
 pub struct Str;
 
 impl BytesEncode<'_> for Str {
     type EItem = str;
+    type Err = Infallible;
 
-    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, BoxedError> {
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, Self::Err> {
         Ok(Cow::Borrowed(item.as_bytes()))
     }
 }
 
 impl<'a> BytesDecode<'a> for Str {
     type DItem = &'a str;
+    type Err = Utf8Error;
 
-    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
-        std::str::from_utf8(bytes).map_err(Into::into)
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Self::Err> {
+        std::str::from_utf8(bytes)
     }
 }

--- a/heed-types/src/unit.rs
+++ b/heed-types/src/unit.rs
@@ -1,27 +1,30 @@
 use std::borrow::Cow;
+use std::convert::Infallible;
 
 use bytemuck::PodCastError;
-use heed_traits::{BoxedError, BytesDecode, BytesEncode};
+use heed_traits::{BytesDecode, BytesEncode};
 
 /// Describes the `()` type.
 pub struct Unit;
 
 impl BytesEncode<'_> for Unit {
     type EItem = ();
+    type Err = Infallible;
 
-    fn bytes_encode(_item: &Self::EItem) -> Result<Cow<[u8]>, BoxedError> {
+    fn bytes_encode(_item: &Self::EItem) -> Result<Cow<[u8]>, Self::Err> {
         Ok(Cow::Borrowed(&[]))
     }
 }
 
 impl BytesDecode<'_> for Unit {
     type DItem = ();
+    type Err = PodCastError;
 
-    fn bytes_decode(bytes: &[u8]) -> Result<Self::DItem, BoxedError> {
+    fn bytes_decode(bytes: &[u8]) -> Result<Self::DItem, Self::Err> {
         if bytes.is_empty() {
             Ok(())
         } else {
-            Err(PodCastError::SizeMismatch.into())
+            Err(PodCastError::SizeMismatch)
         }
     }
 }

--- a/heed/src/db/polymorph.rs
+++ b/heed/src/db/polymorph.rs
@@ -153,7 +153,7 @@ impl PolyDatabase {
         &self,
         txn: &'txn RoTxn,
         key: &'a KC::EItem,
-    ) -> Result<Option<DC::DItem>>
+    ) -> Result<Option<DC::DItem>, KC::Err, DC::Err>
     where
         KC: BytesEncode<'a>,
         DC: BytesDecode<'txn>,
@@ -227,7 +227,7 @@ impl PolyDatabase {
         &self,
         txn: &'txn RoTxn,
         key: &'a KC::EItem,
-    ) -> Result<Option<(KC::DItem, DC::DItem)>>
+    ) -> Result<Option<(KC::DItem, DC::DItem)>, KC::Err, DC::Err>
     where
         KC: BytesEncode<'a> + BytesDecode<'txn>,
         DC: BytesDecode<'txn>,

--- a/heed/src/lazy_decode.rs
+++ b/heed/src/lazy_decode.rs
@@ -1,6 +1,5 @@
+use std::convert::Infallible;
 use std::marker;
-
-use heed_traits::BoxedError;
 
 /// Lazily decode the data bytes, it can be used to avoid CPU intensive decoding
 /// before making sure we really need to decode it (e.g. based on the key).
@@ -9,8 +8,9 @@ pub struct LazyDecode<C>(marker::PhantomData<C>);
 
 impl<'a, C: 'static> heed_traits::BytesDecode<'a> for LazyDecode<C> {
     type DItem = Lazy<'a, C>;
+    type Err = Infallible;
 
-    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Self::Err> {
         Ok(Lazy { data: bytes, _phantom: marker::PhantomData })
     }
 }
@@ -23,7 +23,7 @@ pub struct Lazy<'a, C> {
 }
 
 impl<'a, C: heed_traits::BytesDecode<'a>> Lazy<'a, C> {
-    pub fn decode(&self) -> Result<C::DItem, BoxedError> {
+    pub fn decode(&self) -> Result<C::DItem, C::Err> {
         C::bytes_decode(self.data)
     }
 }


### PR DESCRIPTION
This PR is an attempt at getting rid of the `BoxedError` type we currently use everywhere.
That allows us to use a « real » type when an error arises in the `BytesEncode` or `BytesDecode` traits.

## The new traits

```rust
/// A trait that represents an encoding structure.
pub trait BytesEncode<'a> {
    type EItem: ?Sized + 'a;
    type Err;

    fn bytes_encode(item: &'a Self::EItem) -> Result<Cow<'a, [u8]>, Self::Err>;
}

/// A trait that represents a decoding structure.
pub trait BytesDecode<'a> {
    type DItem: 'a;
    type Err;

    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, Self::Err>;
}
```

I called the type `Err` to do something similar to the [`FromStr`](https://doc.rust-lang.org/stable/std/str/trait.FromStr.html) trait from the stdlib.

## The new `Error` enum

```rust
/// An error that encapsulates all possible errors in this crate.
#[derive(Debug)]
pub enum Error<E, D> {
    Io(io::Error),
    Mdb(MdbError),
    Encoding(E),
    Decoding(D),
    InvalidDatabaseTyping,
    DatabaseClosing,
    BadOpenOptions {
        /// The options that were used to originaly open this env.
        options: EnvOpenOptions,
        /// The env opened with the original options.
        env: Env,
    },
}
```

I had to make the `Error` enum generic over the decoding and encoding error.

For most functions, that do not add any complexity because we use our `Result` type;
```rust
/// Either a success or an [`Error`].
pub type Result<T, E = Infallible, D = Infallible> = result::Result<T, Error<E, D>>;
```

That set `E` and `D` to `Infallible` by default.

## My issue

For some methods like the following one, we can return an error while encoding the key OR the value + while decoding the key OR the value:
```rust
    pub fn get_lower_than<'a, 'txn, KC, DC>(
        &self,
        txn: &'txn RoTxn,
        key: &'a KC::EItem,
    ) -> Result<Option<(KC::DItem, DC::DItem)>, KC::Err, DC::Err>
    where
        KC: BytesEncode<'a> + BytesDecode<'txn>,
        DC: BytesDecode<'txn>,
    {
        assert_eq_env_db_txn!(self, txn);

        let mut cursor = RoCursor::new(txn, self.dbi)?;
        let key_bytes: Cow<[u8]> = KC::bytes_encode(&key).map_err(Error::Encoding)?;
        cursor.move_on_key_greater_than_or_equal_to(&key_bytes)?;

        match cursor.move_on_prev() {
            Ok(Some((key, data))) => match (KC::bytes_decode(key), DC::bytes_decode(data)) {
                (Ok(key), Ok(data)) => Ok(Some((key, data))),
                (Err(e), _) | (_, Err(e)) => Err(Error::Decoding(e)),
            },
            Ok(None) => Ok(None),
            Err(e) => Err(e),
        }
    }
```

One solution could be adding two other variants to the `Error` enum. 