### PR TITLE
Ask the user a write transaction to create a database

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,33 +32,3 @@ jobs:
           cd heed
           cargo clean
           cargo test --features 'lmdb serde-json' --no-default-features
-
-  check_mdbx:
-    name: Test the heed project with MDBX
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        include:
-          - os: ubuntu-latest
-            artifact_name: meilidb-http
-            asset_name: meilidb-http-linux-amd64
-          - os: windows-latest
-            artifact_name: meilidb-http.exe
-            asset_name: meilidb-http-windows-amd64
-          - os: macos-latest
-            artifact_name: meilidb-http-macos-amd64
-            asset_name: meilidb-http-macos-amd64
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Run cargo test
-        run: |
-          cd heed
-          cargo clean
-          cargo test --features 'mdbx serde-json' --no-default-features

--- a/heed/examples/all-types-poly.rs
+++ b/heed/examples/all-types-poly.rs
@@ -22,9 +22,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     //
     // like here we specify that the key will be an array of two i32
     // and the data will be an str
-    let db = env.create_poly_database(Some("kikou"))?;
-
     let mut wtxn = env.write_txn()?;
+    let db = env.create_poly_database(&mut wtxn, Some("kikou"))?;
+
     db.put::<_, OwnedType<[i32; 2]>, Str>(&mut wtxn, &[2, 3], "what's up?")?;
     let ret = db.get::<_, OwnedType<[i32; 2]>, Str>(&wtxn, &[2, 3])?;
 
@@ -32,9 +32,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     wtxn.commit()?;
 
     // here the key will be an str and the data will be a slice of u8
-    let db = env.create_poly_database(Some("kiki"))?;
-
     let mut wtxn = env.write_txn()?;
+    let db = env.create_poly_database(&mut wtxn, Some("kiki"))?;
+
     db.put::<_, Str, ByteSlice>(&mut wtxn, "hello", &[2, 3][..])?;
     let ret = db.get::<_, Str, ByteSlice>(&wtxn, "hello")?;
 
@@ -47,9 +47,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         string: &'a str,
     }
 
-    let db = env.create_poly_database(Some("serde"))?;
-
     let mut wtxn = env.write_txn()?;
+    let db = env.create_poly_database(&mut wtxn, Some("serde"))?;
 
     let hello = Hello { string: "hi" };
     db.put::<_, Str, SerdeBincode<Hello>>(&mut wtxn, "hello", &hello)?;
@@ -72,9 +71,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         bytes: [u8; 12],
     }
 
-    let db = env.create_poly_database(Some("zerocopy-struct"))?;
-
     let mut wtxn = env.write_txn()?;
+    let db = env.create_poly_database(&mut wtxn, Some("zerocopy-struct"))?;
 
     let zerobytes = ZeroBytes { bytes: [24; 12] };
     db.put::<_, Str, UnalignedType<ZeroBytes>>(&mut wtxn, "zero", &zerobytes)?;
@@ -85,9 +83,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     wtxn.commit()?;
 
     // you can ignore the data
-    let db = env.create_poly_database(Some("ignored-data"))?;
-
     let mut wtxn = env.write_txn()?;
+    let db = env.create_poly_database(&mut wtxn, Some("ignored-data"))?;
+
     db.put::<_, Str, Unit>(&mut wtxn, "hello", &())?;
     let ret = db.get::<_, Str, Unit>(&wtxn, "hello")?;
 
@@ -101,7 +99,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     // database opening and types are tested in a way
     //
     // we try to open a database twice with the same types
-    let _db = env.create_poly_database(Some("ignored-data"))?;
+    let mut wtxn = env.write_txn()?;
+    let _db = env.create_poly_database(&mut wtxn, Some("ignored-data"))?;
 
     // and here we try to open it with other types
     // asserting that it correctly returns an error
@@ -109,15 +108,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     // NOTE that those types are not saved upon runs and
     // therefore types cannot be checked upon different runs,
     // the first database opening fix the types for this run.
-    let result = env.create_database::<OwnedType<BEI64>, Unit>(Some("ignored-data"));
+    let result = env.create_database::<OwnedType<BEI64>, Unit>(&mut wtxn, Some("ignored-data"));
     assert!(result.is_err());
 
     // you can iterate over keys in order
     type BEI64 = I64<BE>;
 
-    let db = env.create_poly_database(Some("big-endian-iter"))?;
-
     let mut wtxn = env.write_txn()?;
+    let db = env.create_poly_database(&mut wtxn, Some("big-endian-iter"))?;
+
     db.put::<_, OwnedType<BEI64>, Unit>(&mut wtxn, &BEI64::new(0), &())?;
     db.put::<_, OwnedType<BEI64>, Unit>(&mut wtxn, &BEI64::new(68), &())?;
     db.put::<_, OwnedType<BEI64>, Unit>(&mut wtxn, &BEI64::new(35), &())?;

--- a/heed/examples/clear-database.rs
+++ b/heed/examples/clear-database.rs
@@ -18,8 +18,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .max_dbs(3)
         .open(env_path)?;
 
-    let db: Database<Str, Str> = env.create_database(Some("first"))?;
     let mut wtxn = env.write_txn()?;
+    let db: Database<Str, Str> = env.create_database(&mut wtxn, Some("first"))?;
 
     // We fill the db database with entries.
     db.put(&mut wtxn, "I am here", "to test things")?;

--- a/heed/examples/cursor-append.rs
+++ b/heed/examples/cursor-append.rs
@@ -18,10 +18,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         .max_dbs(3)
         .open(env_path)?;
 
-    let first: Database<Str, Str> = env.create_database(Some("first"))?;
-    let second: Database<Str, Str> = env.create_database(Some("second"))?;
-
     let mut wtxn = env.write_txn()?;
+    let first: Database<Str, Str> = env.create_database(&mut wtxn, Some("first"))?;
+    let second: Database<Str, Str> = env.create_database(&mut wtxn, Some("second"))?;
 
     // We fill the first database with entries.
     first.put(&mut wtxn, "I am here", "to test things")?;

--- a/heed/examples/multi-env.rs
+++ b/heed/examples/multi-env.rs
@@ -21,8 +21,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         .max_dbs(3000)
         .open(env2_path)?;
 
-    let db1: Database<Str, ByteSlice> = env1.create_database(Some("hello"))?;
-    let db2: Database<OwnedType<u32>, OwnedType<u32>> = env2.create_database(Some("hello"))?;
+    let mut wtxn = env1.write_txn()?;
+    let db1: Database<Str, ByteSlice> = env1.create_database(&mut wtxn, Some("hello"))?;
+    let db2: Database<OwnedType<u32>, OwnedType<u32>> =
+        env2.create_database(&mut wtxn, Some("hello"))?;
+    wtxn.commit()?;
 
     // clear db
     let mut wtxn = env1.write_txn()?;

--- a/heed/examples/nested.rs
+++ b/heed/examples/nested.rs
@@ -16,7 +16,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         .open(path)?;
 
     // here the key will be an str and the data will be a slice of u8
-    let db: Database<Str, ByteSlice> = env.create_database(None)?;
+    let mut wtxn = env.write_txn()?;
+    let db: Database<Str, ByteSlice> = env.create_database(&mut wtxn, None)?;
+    wtxn.commit()?;
 
     // clear db
     let mut wtxn = env.write_txn()?;

--- a/heed/src/db/polymorph.rs
+++ b/heed/src/db/polymorph.rs
@@ -31,9 +31,9 @@ use crate::*;
 /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
 ///
-/// let db: PolyDatabase = env.create_poly_database(Some("big-endian-iter"))?;
-///
 /// let mut wtxn = env.write_txn()?;
+/// let db: PolyDatabase = env.create_poly_database(&mut wtxn, Some("big-endian-iter"))?;
+///
 /// # db.clear(&mut wtxn)?;
 /// db.put::<_, OwnedType<BEI64>, Unit>(&mut wtxn, &BEI64::new(0), &())?;
 /// db.put::<_, OwnedType<BEI64>, Str>(&mut wtxn, &BEI64::new(35), "thirty five")?;
@@ -74,9 +74,9 @@ use crate::*;
 /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
 ///
-/// let db: PolyDatabase = env.create_poly_database(Some("big-endian-iter"))?;
-///
 /// let mut wtxn = env.write_txn()?;
+/// let db: PolyDatabase = env.create_poly_database(&mut wtxn, Some("big-endian-iter"))?;
+///
 /// # db.clear(&mut wtxn)?;
 /// db.put::<_, OwnedType<BEI64>, Unit>(&mut wtxn, &BEI64::new(0), &())?;
 /// db.put::<_, OwnedType<BEI64>, Str>(&mut wtxn, &BEI64::new(35), "thirty five")?;
@@ -130,7 +130,9 @@ impl PolyDatabase {
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
-    /// let db = env.create_poly_database(Some("use-sequence-1"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("use-sequence-1"))?;
+    /// wtxn.commit()?;
     ///
     /// // The sequence starts at zero
     /// let rtxn = env.read_txn()?;
@@ -195,7 +197,9 @@ impl PolyDatabase {
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
-    /// let db = env.create_poly_database(Some("use-sequence-2"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("use-sequence-2"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// let incr = db.increase_sequence(&mut wtxn, 32)?;
@@ -246,7 +250,9 @@ impl PolyDatabase {
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
-    /// let db = env.create_poly_database(Some("get-poly-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("get-poly-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -316,7 +322,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEU32 = U32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("get-lt-u32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("get-lt-u32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -384,7 +392,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEU32 = U32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("get-lte-u32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("get-lte-u32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -456,7 +466,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEU32 = U32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("get-lt-u32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("get-lt-u32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -527,7 +539,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEU32 = U32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("get-lt-u32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("get-lt-u32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -592,7 +606,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("first-poly-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("first-poly-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -648,7 +664,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("last-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("last-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -700,7 +718,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -756,7 +776,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -804,7 +826,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -846,7 +870,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -904,7 +930,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -950,7 +978,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -1010,7 +1040,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -1088,7 +1120,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -1179,7 +1213,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -1257,7 +1293,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -1348,7 +1386,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -1404,7 +1444,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -1473,7 +1515,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -1529,9 +1573,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put::<_, Str, OwnedType<BEI32>>(&mut wtxn, "i-am-twenty-eight", &BEI32::new(28))?;
     /// db.put::<_, Str, OwnedType<BEI32>>(&mut wtxn, "i-am-twenty-seven", &BEI32::new(27))?;
@@ -1595,9 +1639,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put::<_, OwnedType<BEI32>, Str>(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put::<_, OwnedType<BEI32>, Str>(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -1657,9 +1701,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("append-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("append-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put::<_, OwnedType<BEI32>, Str>(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
     /// db.put::<_, OwnedType<BEI32>, Str>(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -1718,7 +1762,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -1784,7 +1830,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -1854,7 +1902,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;
@@ -1903,7 +1953,9 @@ impl PolyDatabase {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db = env.create_poly_database(Some("iter-i32"))?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_poly_database(&mut wtxn, Some("iter-i32"))?;
+    /// wtxn.commit()?;
     ///
     /// let mut wtxn = env.write_txn()?;
     /// # db.clear(&mut wtxn)?;

--- a/heed/src/db/uniform.rs
+++ b/heed/src/db/uniform.rs
@@ -28,9 +28,9 @@ use crate::*;
 /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
 ///
-/// let db: Database<OwnedType<BEI64>, Unit> = env.create_database(Some("big-endian-iter"))?;
-///
 /// let mut wtxn = env.write_txn()?;
+/// let db: Database<OwnedType<BEI64>, Unit> = env.create_database(&mut wtxn, Some("big-endian-iter"))?;
+///
 /// # db.clear(&mut wtxn)?;
 /// db.put(&mut wtxn, &BEI64::new(68), &())?;
 /// db.put(&mut wtxn, &BEI64::new(35), &())?;
@@ -75,9 +75,9 @@ use crate::*;
 /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
 /// type BEI64 = I64<BigEndian>;
 ///
-/// let db: Database<OwnedType<BEI64>, Unit> = env.create_database(Some("big-endian-iter"))?;
-///
 /// let mut wtxn = env.write_txn()?;
+/// let db: Database<OwnedType<BEI64>, Unit> = env.create_database(&mut wtxn, Some("big-endian-iter"))?;
+///
 /// # db.clear(&mut wtxn)?;
 /// db.put(&mut wtxn, &BEI64::new(0), &())?;
 /// db.put(&mut wtxn, &BEI64::new(68), &())?;
@@ -164,9 +164,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
-    /// let db: Database<Str, OwnedType<i32>> = env.create_database(Some("get-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<Str, OwnedType<i32>> = env.create_database(&mut wtxn, Some("get-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, "i-am-forty-two", &42)?;
     /// db.put(&mut wtxn, "i-am-twenty-seven", &27)?;
@@ -215,9 +215,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEU32 = U32<BigEndian>;
     ///
-    /// let db = env.create_database::<OwnedType<BEU32>, Unit>(Some("get-lt-u32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_database::<OwnedType<BEU32>, Unit>(&mut wtxn, Some("get-lt-u32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEU32::new(27), &())?;
     /// db.put(&mut wtxn, &BEU32::new(42), &())?;
@@ -270,9 +270,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEU32 = U32<BigEndian>;
     ///
-    /// let db = env.create_database::<OwnedType<BEU32>, Unit>(Some("get-lt-u32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_database::<OwnedType<BEU32>, Unit>(&mut wtxn, Some("get-lt-u32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEU32::new(27), &())?;
     /// db.put(&mut wtxn, &BEU32::new(42), &())?;
@@ -325,9 +325,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEU32 = U32<BigEndian>;
     ///
-    /// let db = env.create_database::<OwnedType<BEU32>, Unit>(Some("get-lt-u32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_database::<OwnedType<BEU32>, Unit>(&mut wtxn, Some("get-lt-u32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEU32::new(27), &())?;
     /// db.put(&mut wtxn, &BEU32::new(42), &())?;
@@ -380,9 +380,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEU32 = U32<BigEndian>;
     ///
-    /// let db = env.create_database::<OwnedType<BEU32>, Unit>(Some("get-lt-u32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db = env.create_database::<OwnedType<BEU32>, Unit>(&mut wtxn, Some("get-lt-u32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEU32::new(27), &())?;
     /// db.put(&mut wtxn, &BEU32::new(42), &())?;
@@ -434,9 +434,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("first-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("first-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -477,9 +477,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("last-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("last-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -516,9 +516,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -558,9 +558,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -600,9 +600,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -640,9 +640,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -693,9 +693,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -734,9 +734,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -792,9 +792,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -844,9 +844,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -909,9 +909,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -961,9 +961,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -1026,9 +1026,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, "i-am-twenty-eight", &BEI32::new(28))?;
     /// db.put(&mut wtxn, "i-am-twenty-seven", &BEI32::new(27))?;
@@ -1078,9 +1078,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, "i-am-twenty-eight", &BEI32::new(28))?;
     /// db.put(&mut wtxn, "i-am-twenty-seven", &BEI32::new(27))?;
@@ -1143,9 +1143,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, "i-am-twenty-eight", &BEI32::new(28))?;
     /// db.put(&mut wtxn, "i-am-twenty-seven", &BEI32::new(27))?;
@@ -1195,9 +1195,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<Str, OwnedType<BEI32>> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, "i-am-twenty-eight", &BEI32::new(28))?;
     /// db.put(&mut wtxn, "i-am-twenty-seven", &BEI32::new(27))?;
@@ -1257,9 +1257,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -1306,9 +1306,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(13), "i-am-thirteen")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -1354,9 +1354,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -1407,9 +1407,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -1465,9 +1465,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;
@@ -1512,9 +1512,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<Unit, Unit> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<Unit, Unit> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// // We remap the types for ease of use.
     /// let db = db.remap_types::<OwnedType<BEI32>, Str>();
@@ -1576,9 +1576,9 @@ impl<KC, DC> Database<KC, DC> {
     /// #     .open(Path::new("target").join("zerocopy.mdb"))?;
     /// type BEI32 = I32<BigEndian>;
     ///
-    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(Some("iter-i32"))?;
-    ///
     /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<OwnedType<BEI32>, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
     /// # db.clear(&mut wtxn)?;
     /// db.put(&mut wtxn, &BEI32::new(42), "i-am-forty-two")?;
     /// db.put(&mut wtxn, &BEI32::new(27), "i-am-twenty-seven")?;

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -622,10 +622,10 @@ mod tests {
             thread::sleep(Duration::from_secs(1));
         });
 
-        let db = env.create_database::<Str, Str>(None).unwrap();
+        let mut wtxn = env.write_txn().unwrap();
+        let db = env.create_database::<Str, Str>(&mut wtxn, None).unwrap();
 
         // Create an ordered list of keys...
-        let mut wtxn = env.write_txn().unwrap();
         db.put(&mut wtxn, "hello", "hello").unwrap();
         db.put(&mut wtxn, "world", "world").unwrap();
 

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -121,10 +121,10 @@ impl EnvOpenOptions {
     /// let env = env_builder.open(Path::new("target").join("zerocopy.mdb"))?;
     ///
     /// // we will open the default unamed database
-    /// let db: Database<Str, OwnedType<i32>> = env.create_database(None)?;
+    /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<Str, OwnedType<i32>> = env.create_database(&mut wtxn, None)?;
     ///
     /// // opening a write transaction
-    /// let mut wtxn = env.write_txn()?;
     /// db.put(&mut wtxn, "seven", &7)?;
     /// db.put(&mut wtxn, "zero", &0)?;
     /// db.put(&mut wtxn, "five", &5)?;

--- a/heed/src/iter/mod.rs
+++ b/heed/src/iter/mod.rs
@@ -39,10 +39,10 @@ mod tests {
             .max_dbs(3000)
             .open(Path::new("target").join("prefix_iter_with_byte_255.mdb"))
             .unwrap();
-        let db = env.create_database::<ByteSlice, Str>(None).unwrap();
+        let mut wtxn = env.write_txn().unwrap();
+        let db = env.create_database::<ByteSlice, Str>(&mut wtxn, None).unwrap();
 
         // Create an ordered list of keys...
-        let mut wtxn = env.write_txn().unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], "world").unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], "hello").unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], "world").unwrap();
@@ -80,11 +80,11 @@ mod tests {
             .max_dbs(3000)
             .open(Path::new("target").join("iter_last.mdb"))
             .unwrap();
-        let db = env.create_database::<OwnedType<BEI32>, Unit>(None).unwrap();
+        let mut wtxn = env.write_txn().unwrap();
+        let db = env.create_database::<OwnedType<BEI32>, Unit>(&mut wtxn, None).unwrap();
         type BEI32 = I32<BigEndian>;
 
         // Create an ordered list of keys...
-        let mut wtxn = env.write_txn().unwrap();
         db.put(&mut wtxn, &BEI32::new(1), &()).unwrap();
         db.put(&mut wtxn, &BEI32::new(2), &()).unwrap();
         db.put(&mut wtxn, &BEI32::new(3), &()).unwrap();
@@ -148,11 +148,11 @@ mod tests {
             .max_dbs(3000)
             .open(Path::new("target").join("iter_last.mdb"))
             .unwrap();
-        let db = env.create_database::<OwnedType<BEI32>, Unit>(None).unwrap();
+        let mut wtxn = env.write_txn().unwrap();
+        let db = env.create_database::<OwnedType<BEI32>, Unit>(&mut wtxn, None).unwrap();
         type BEI32 = I32<BigEndian>;
 
         // Create an ordered list of keys...
-        let mut wtxn = env.write_txn().unwrap();
         db.put(&mut wtxn, &BEI32::new(1), &()).unwrap();
         db.put(&mut wtxn, &BEI32::new(2), &()).unwrap();
         db.put(&mut wtxn, &BEI32::new(3), &()).unwrap();
@@ -238,10 +238,10 @@ mod tests {
             .max_dbs(3000)
             .open(Path::new("target").join("prefix_iter_last.mdb"))
             .unwrap();
-        let db = env.create_database::<ByteSlice, Unit>(None).unwrap();
+        let mut wtxn = env.write_txn().unwrap();
+        let db = env.create_database::<ByteSlice, Unit>(&mut wtxn, None).unwrap();
 
         // Create an ordered list of keys...
-        let mut wtxn = env.write_txn().unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], &()).unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], &()).unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], &()).unwrap();
@@ -313,10 +313,10 @@ mod tests {
             .max_dbs(3000)
             .open(Path::new("target").join("prefix_iter_last.mdb"))
             .unwrap();
-        let db = env.create_database::<ByteSlice, Unit>(None).unwrap();
+        let mut wtxn = env.write_txn().unwrap();
+        let db = env.create_database::<ByteSlice, Unit>(&mut wtxn, None).unwrap();
 
         // Create an ordered list of keys...
-        let mut wtxn = env.write_txn().unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], &()).unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], &()).unwrap();
         db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], &()).unwrap();
@@ -390,11 +390,11 @@ mod tests {
             .max_dbs(3000)
             .open(Path::new("target").join("range_iter_last.mdb"))
             .unwrap();
-        let db = env.create_database::<OwnedType<BEI32>, Unit>(None).unwrap();
+        let mut wtxn = env.write_txn().unwrap();
+        let db = env.create_database::<OwnedType<BEI32>, Unit>(&mut wtxn, None).unwrap();
         type BEI32 = I32<BigEndian>;
 
         // Create an ordered list of keys...
-        let mut wtxn = env.write_txn().unwrap();
         db.put(&mut wtxn, &BEI32::new(1), &()).unwrap();
         db.put(&mut wtxn, &BEI32::new(2), &()).unwrap();
         db.put(&mut wtxn, &BEI32::new(3), &()).unwrap();

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -25,10 +25,10 @@
 //! let env = EnvOpenOptions::new().open(Path::new("target").join("zerocopy.mdb"))?;
 //!
 //! // we will open the default unamed database
-//! let db: Database<Str, OwnedType<i32>> = env.create_database(None)?;
+//! let mut wtxn = env.write_txn()?;
+//! let db: Database<Str, OwnedType<i32>> = env.create_database(&mut wtxn, None)?;
 //!
 //! // opening a write transaction
-//! let mut wtxn = env.write_txn()?;
 //! db.put(&mut wtxn, "seven", &7)?;
 //! db.put(&mut wtxn, "zero", &0)?;
 //! db.put(&mut wtxn, "five", &5)?;


### PR DESCRIPTION
This PR removes the use of subtransactions to create a database that users use heed with some important LMDB options, e.g., `MDB_WRITE_MAP`. It is breaking, but as this branch was never released on crates.io and is only used by [the Meilisearch team](https://github.com/meiliisearch) 🤷