### PR TITLE
Fix the impl of `Sync` for `RoTxn`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 name: Rust
 jobs:
-  check:
+  test:
     name: Test the heed project
     runs-on: ${{ matrix.os }}
     strategy:
@@ -27,6 +27,31 @@ jobs:
         run: |
           cargo clean
           cargo test
+
+  check_all_features:
+    name: Check all the features of the heed project
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run cargo test
+        run: |
+          cd heed
+          cargo clean
+          cargo check --all-features
 
   examples:
     name: Run the heed examples

--- a/heed/src/txn.rs
+++ b/heed/src/txn.rs
@@ -41,7 +41,7 @@ impl Drop for RoTxn<'_> {
 }
 
 #[cfg(feature = "sync-read-txn")]
-unsafe impl<T> Sync for RoTxn<'_> {}
+unsafe impl Sync for RoTxn<'_> {}
 
 fn abort_txn(txn: *mut ffi::MDB_txn) {
     // Asserts that the transaction hasn't been already committed.


### PR DESCRIPTION
This PR makes sure that the Sync trait is correctly implemented on the `RoTxn` when the `sync-read-txn` feature is enabled. It also updates the GitHub CI to make sure we do not break it in further versions of the crate.