### PR TITLE
Bump version to v0.20.0-alpha.1

### DIFF
--- a/heed-traits/Cargo.toml
+++ b/heed-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heed-traits"
-version = "0.20.0-alpha.0"
+version = "0.20.0-alpha.1"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
 description = "The traits used inside of the fully typed LMDB wrapper, heed"
 license = "MIT"

--- a/heed-types/Cargo.toml
+++ b/heed-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heed-types"
-version = "0.20.0-alpha.0"
+version = "0.20.0-alpha.1"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
 description = "The types used with the fully typed LMDB wrapper, heed"
 license = "MIT"
@@ -10,7 +10,10 @@ edition = "2021"
 
 [dependencies]
 bincode = { version = "1.3.3", optional = true }
-bytemuck = { version = "1.12.3", features = ["extern_crate_alloc", "extern_crate_std"] }
+bytemuck = { version = "1.12.3", features = [
+    "extern_crate_alloc",
+    "extern_crate_std",
+] }
 byteorder = "1.4.3"
 heed-traits = { version = "0.20.0-alpha.0", path = "../heed-traits" }
 serde = { version = "1.0.151", optional = true }

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heed"
-version = "0.20.0-alpha.0"
+version = "0.20.0-alpha.1"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
 description = "A fully typed LMDB wrapper with minimum overhead"
 license = "MIT"


### PR DESCRIPTION
This PR bumps the version of the heed, heed-types, and heed-traits crates.