### PR TITLE
Disable default-features for `heed-types` crate

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 bytemuck = "1.12.3"
 byteorder = { version = "1.4.3", default-features = false }
 heed-traits = { version = "0.20.0-alpha.0", path = "../heed-traits" }
-heed-types = { version = "0.20.0-alpha.0", path = "../heed-types" }
+heed-types = { version = "0.20.0-alpha.0", default-features = false, path = "../heed-types" }
 libc = "0.2.139"
 lmdb-master-sys = { version = "0.1.0", path = "../lmdb-master-sys" }
 once_cell = "1.16.0"


### PR DESCRIPTION
# Pull Request

## What does this PR do?

This allows building without pulling in unused dependencies.

The following command should print an error, because the `serde-json` feature is not enabled:

```
$ cargo tree --no-default-features --features 'serde-bincode' -i serde_json
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?