### PR TITLE
Fix warnings

### DIFF
--- a/heed-types/src/integer.rs
+++ b/heed-types/src/integer.rs
@@ -49,9 +49,9 @@ macro_rules! define_type {
             type EItem = $native;
 
             fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, BoxedError> {
-                let mut buf = [0; size_of::<Self::EItem>()];
+                let mut buf = vec![0; size_of::<Self::EItem>()];
                 O::$write_method(&mut buf, *item);
-                Ok(Cow::from(buf.to_vec()))
+                Ok(Cow::from(buf))
             }
         }
 

--- a/lmdb-master-sys/Cargo.toml
+++ b/lmdb-master-sys/Cargo.toml
@@ -31,6 +31,9 @@ cc = "1.0.78"
 doxygen-rs = "0.2.2"
 pkg-config = "0.3.26"
 
+[dev-dependencies]
+cstr = "0.2.11"
+
 [features]
 default = []
 asan = []


### PR DESCRIPTION
This PR fixes some warnings when either building or testing the crate. Only the `cstr` dev-dependency has been added. And no perf regression should be seen.