### PR TITLE
Bump version to v0.20.0-alpha.2

### DIFF
--- a/heed-traits/Cargo.toml
+++ b/heed-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heed-traits"
-version = "0.20.0-alpha.1"
+version = "0.20.0-alpha.2"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
 description = "The traits used inside of the fully typed LMDB wrapper, heed"
 license = "MIT"

--- a/heed-types/Cargo.toml
+++ b/heed-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heed-types"
-version = "0.20.0-alpha.1"
+version = "0.20.0-alpha.2"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
 description = "The types used with the fully typed LMDB wrapper, heed"
 license = "MIT"

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heed"
-version = "0.20.0-alpha.1"
+version = "0.20.0-alpha.2"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
 description = "A fully typed LMDB wrapper with minimum overhead"
 license = "MIT"


### PR DESCRIPTION
This PR bumps the different crate versions in order to publish it on crates.io.