### PR TITLE
Fix the the serde-json feature declaration of heed

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -42,7 +42,7 @@ sync-read-txn = []
 
 # Enable the serde en/decoders for bincode or serde_json
 serde-bincode = ["heed-types/serde", "heed-types/bincode"]
-serde-json = ["heed-types/serde", "heed-types/serde_json"]
+serde-json = ["heed-types/serde", "heed-types/serde-json"]
 
 # serde_json features
 preserve_order = ["heed-types/preserve_order"]


### PR DESCRIPTION
We made a small mistake in https://github.com/meilisearch/heed/pull/171 where we disabled the default features by default but did a misspelling of the `serde-json` feature.