### PR TITLE
Bump version to v0.20.0-alpha.3

### DIFF
--- a/heed-traits/Cargo.toml
+++ b/heed-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heed-traits"
-version = "0.20.0-alpha.2"
+version = "0.20.0-alpha.3"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
 description = "The traits used inside of the fully typed LMDB wrapper, heed"
 license = "MIT"

--- a/heed-types/Cargo.toml
+++ b/heed-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heed-types"
-version = "0.20.0-alpha.2"
+version = "0.20.0-alpha.3"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
 description = "The types used with the fully typed LMDB wrapper, heed"
 license = "MIT"
@@ -15,7 +15,7 @@ bytemuck = { version = "1.12.3", features = [
     "extern_crate_std",
 ] }
 byteorder = "1.4.3"
-heed-traits = { version = "0.20.0-alpha.0", path = "../heed-traits" }
+heed-traits = { version = "0.20.0-alpha.3", path = "../heed-traits" }
 serde = { version = "1.0.151", optional = true }
 serde_json = { version = "1.0.91", optional = true }
 

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heed"
-version = "0.20.0-alpha.2"
+version = "0.20.0-alpha.3"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
 description = "A fully typed LMDB wrapper with minimum overhead"
 license = "MIT"
@@ -13,8 +13,8 @@ edition = "2021"
 [dependencies]
 bytemuck = "1.12.3"
 byteorder = { version = "1.4.3", default-features = false }
-heed-traits = { version = "0.20.0-alpha.0", path = "../heed-traits" }
-heed-types = { version = "0.20.0-alpha.0", default-features = false, path = "../heed-types" }
+heed-traits = { version = "0.20.0-alpha.3", path = "../heed-traits" }
+heed-types = { version = "0.20.0-alpha.3", default-features = false, path = "../heed-types" }
 libc = "0.2.139"
 lmdb-master-sys = { version = "0.1.0", path = "../lmdb-master-sys" }
 once_cell = "1.16.0"


### PR DESCRIPTION
This PR bumps the different crate versions in order to publish it on crates.io.