### PR TITLE
Replace the `&mut RwTxn` by `&RwTxn`

### DIFF
--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -813,7 +813,7 @@ mod tests {
         let env = EnvOpenOptions::new()
             .map_size(10 * 1024 * 1024) // 10MB
             .max_dbs(30)
-            .open(&dir.path())
+            .open(dir.path())
             .unwrap();
 
         // Force a thread to keep the env for 1 second.
@@ -847,7 +847,7 @@ mod tests {
         eprintln!("env closed successfully");
 
         // Make sure we don't have a reference to the env
-        assert!(env_closing_event(&dir.path()).is_none());
+        assert!(env_closing_event(dir.path()).is_none());
     }
 
     #[test]
@@ -855,12 +855,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let _env = EnvOpenOptions::new()
             .map_size(10 * 1024 * 1024) // 10MB
-            .open(&dir.path())
+            .open(dir.path())
             .unwrap();
 
         let result = EnvOpenOptions::new()
             .map_size(12 * 1024 * 1024) // 12MB
-            .open(&dir.path());
+            .open(dir.path());
 
         assert!(matches!(result, Err(Error::BadOpenOptions { .. })));
     }
@@ -888,7 +888,7 @@ mod tests {
         envbuilder.map_size(10 * 1024 * 1024); // 10MB
         envbuilder.max_dbs(10);
         unsafe { envbuilder.flag(crate::Flag::WriteMap) };
-        let env = envbuilder.open(&dir.path()).unwrap();
+        let env = envbuilder.open(dir.path()).unwrap();
 
         let mut wtxn = env.write_txn().unwrap();
         let _db = env.create_database::<Str, Str>(&mut wtxn, Some("my-super-db")).unwrap();
@@ -900,7 +900,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut envbuilder = EnvOpenOptions::new();
         unsafe { envbuilder.flag(crate::Flag::NoSubDir) };
-        let _env = envbuilder.open(&dir.path().join("data.mdb")).unwrap();
+        let _env = envbuilder.open(dir.path().join("data.mdb")).unwrap();
     }
 
     #[test]
@@ -909,7 +909,7 @@ mod tests {
         let env = EnvOpenOptions::new()
             .map_size(10 * 1024 * 1024) // 10MB
             .max_dbs(10)
-            .open(&dir.path())
+            .open(dir.path())
             .unwrap();
 
         let mut wtxn = env.write_txn().unwrap();
@@ -927,7 +927,7 @@ mod tests {
         let env = EnvOpenOptions::new()
             .map_size(10 * 1024 * 1024) // 10MB
             .max_dbs(10)
-            .open(&dir.path())
+            .open(dir.path())
             .unwrap();
 
         // we first create a database
@@ -940,7 +940,7 @@ mod tests {
         let env = EnvOpenOptions::new()
             .map_size(10 * 1024 * 1024) // 10MB
             .max_dbs(10)
-            .open(&dir.path())
+            .open(dir.path())
             .unwrap();
 
         let rtxn = env.read_txn().unwrap();
@@ -951,7 +951,7 @@ mod tests {
     #[test]
     fn resize_database() {
         let dir = tempfile::tempdir().unwrap();
-        let env = EnvOpenOptions::new().map_size(9 * 4096).max_dbs(1).open(&dir.path()).unwrap();
+        let env = EnvOpenOptions::new().map_size(9 * 4096).max_dbs(1).open(dir.path()).unwrap();
 
         let mut wtxn = env.write_txn().unwrap();
         let db = env.create_database::<Str, Str>(&mut wtxn, Some("my-super-db")).unwrap();

--- a/heed/src/iterator/mod.rs
+++ b/heed/src/iterator/mod.rs
@@ -203,6 +203,7 @@ mod tests {
         let iter = db.range(&wtxn, &range).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), None);
 
+        #[allow(clippy::reversed_empty_ranges)]
         let range = 2..=1;
         let iter = db.range(&wtxn, &range).unwrap();
         assert_eq!(iter.last().transpose().unwrap(), None);

--- a/lmdb-master-sys/tests/lmdb.rs
+++ b/lmdb-master-sys/tests/lmdb.rs
@@ -9,12 +9,10 @@ fn test_lmdb() {
     lmdb.push("libraries");
     lmdb.push("liblmdb");
 
-    let make_cmd = Command::new("make")
-        .current_dir(&lmdb)
-        .status()
-        .expect("failed to execute process");
+    let make_cmd =
+        Command::new("make").current_dir(&lmdb).status().expect("failed to execute process");
 
-    assert_eq!(make_cmd.success(), true);
+    assert!(make_cmd.success());
 
     let make_test_cmd = Command::new("make")
         .arg("test")
@@ -22,5 +20,5 @@ fn test_lmdb() {
         .status()
         .expect("failed to execute process");
 
-    assert_eq!(make_test_cmd.success(), true);
+    assert!(make_test_cmd.success());
 }

--- a/lmdb-master-sys/tests/simple.rs
+++ b/lmdb-master-sys/tests/simple.rs
@@ -1,9 +1,9 @@
-use cstr::cstr;
-use lmdb_master_sys::*;
-
 use std::ffi::{c_void, CString};
 use std::fs::{self, File};
 use std::ptr;
+
+use cstr::cstr;
+use lmdb_master_sys::*;
 
 // https://github.com/victorporof/lmdb/blob/mdb.master/libraries/liblmdb/moz-test.c
 
@@ -46,14 +46,8 @@ fn test_simple(env_path: &str) {
 
     let mut env: *mut MDB_env = ptr::null_mut();
     let mut dbi: MDB_dbi = 0;
-    let mut key = MDB_val {
-        mv_size: 0,
-        mv_data: ptr::null_mut(),
-    };
-    let mut data = MDB_val {
-        mv_size: 0,
-        mv_data: ptr::null_mut(),
-    };
+    let mut key = MDB_val { mv_size: 0, mv_data: ptr::null_mut() };
+    let mut data = MDB_val { mv_size: 0, mv_data: ptr::null_mut() };
     let mut txn: *mut MDB_txn = ptr::null_mut();
     let sval = cstr!("foo").as_ptr() as *mut c_void;
     let dval = cstr!("bar").as_ptr() as *mut c_void;
@@ -62,15 +56,10 @@ fn test_simple(env_path: &str) {
         E!(mdb_env_create(&mut env));
         E!(mdb_env_set_maxdbs(env, 2));
         let env_path = CString::new(env_path).unwrap();
-        E!(mdb_env_open(env, env_path.as_ptr(), 0, 0664));
+        E!(mdb_env_open(env, env_path.as_ptr(), 0, 0o664));
 
         E!(mdb_txn_begin(env, ptr::null_mut(), 0, &mut txn));
-        E!(mdb_dbi_open(
-            txn,
-            cstr!("subdb").as_ptr(),
-            MDB_CREATE,
-            &mut dbi
-        ));
+        E!(mdb_dbi_open(txn, cstr!("subdb").as_ptr(), MDB_CREATE, &mut dbi));
         E!(mdb_txn_commit(txn));
 
         key.mv_size = 3;


### PR DESCRIPTION
The PR fixes #189 by removing all of the `&mut RwTxn` requirements by simple `&RoTxn`.

Doing so allows very cool use cases like:
 - being able to dump database entries into another one.
 - write into a database with values from the same database.