### PR TITLE
Make the `RoTxn: Send`

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -36,7 +36,7 @@ url = "2.3.1"
 default = ["serde", "serde-bincode", "serde-json"]
 
 # The NO_TLS flag is automatically set on Env opening and
-# RoTxn implements the Sync trait. This allow the user to reference
+# RoTxn implements the Sync and Send traits. This allow the user to reference
 # a read-only transaction from multiple threads at the same time.
 sync-read-txn = []
 

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -36,9 +36,9 @@ url = "2.3.1"
 default = ["serde", "serde-bincode", "serde-json"]
 
 # The NO_TLS flag is automatically set on Env opening and
-# RoTxn implements the Sync and Send traits. This allow the user to reference
-# a read-only transaction from multiple threads at the same time.
-sync-read-txn = []
+# RoTxn implements the Send trait. This allows the user to move
+# a RoTxn between threads.
+send-read-txn = []
 
 # Enable the serde en/decoders for bincode or serde_json
 serde-bincode = ["heed-types/serde", "heed-types/bincode"]

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -246,10 +246,10 @@ impl EnvOpenOptions {
                         mdb_result(ffi::mdb_env_set_maxdbs(env, dbs))?;
                     }
 
-                    // When the `sync-read-txn` feature is enabled, we must force LMDB
+                    // When the `send-read-txn` feature is enabled, we must force LMDB
                     // to avoid using the thread local storage, this way we allow users
                     // to use references of RoTxn between threads safely.
-                    let flags = if cfg!(feature = "sync-read-txn") {
+                    let flags = if cfg!(feature = "send-read-txn") {
                         self.flags | Flag::NoTls as u32
                     } else {
                         self.flags

--- a/heed/src/txn.rs
+++ b/heed/src/txn.rs
@@ -73,10 +73,7 @@ impl Drop for RoTxn<'_> {
     }
 }
 
-#[cfg(feature = "sync-read-txn")]
-unsafe impl Sync for RoTxn<'_> {}
-
-#[cfg(feature = "sync-read-txn")]
+#[cfg(feature = "send-read-txn")]
 unsafe impl Send for RoTxn<'_> {}
 
 fn abort_txn(txn: *mut ffi::MDB_txn) {

--- a/heed/src/txn.rs
+++ b/heed/src/txn.rs
@@ -76,6 +76,9 @@ impl Drop for RoTxn<'_> {
 #[cfg(feature = "sync-read-txn")]
 unsafe impl Sync for RoTxn<'_> {}
 
+#[cfg(feature = "sync-read-txn")]
+unsafe impl Send for RoTxn<'_> {}
+
 fn abort_txn(txn: *mut ffi::MDB_txn) {
     // Asserts that the transaction hasn't been already committed.
     assert!(!txn.is_null());


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #191

## What does this PR do?
We found out that implementing `Sync` for `RoTxn` is unsafe, it should instead only implement `Send`. This PR changes the `sync-read-txn` to `send-read-txn`, and replaces the implementation `Sync` for `RoTxn` with `Send`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
