### PR TITLE
Rename and document the `MDB_NOTLS` feature

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -35,10 +35,20 @@ url = "2.3.1"
 # like the `EnvOpenOptions` struct.
 default = ["serde", "serde-bincode", "serde-json"]
 
-# The NO_TLS flag is automatically set on Env opening and
+# The #MDB_NOTLS flag is automatically set on Env opening and
 # RoTxn implements the Send trait. This allows the user to move
-# a RoTxn between threads.
-send-read-txn = []
+# a RoTxn between threads as read transactions will no more use
+# thread local storage and will tie reader locktable slots to
+# #MDB_txn objects instead of to threads.
+#
+# According to the LMDB documentation, when this feature is not enabled:
+# A thread can only use one transaction at a time, plus any child
+# transactions. Each transaction belongs to one thread. [...]
+# The #MDB_NOTLS flag changes this for read-only transactions.
+#
+# And a #MDB_BAD_RSLOT error will be thrown when multiple read
+# transactions exists on the same thread
+read-txn-no-tls = []
 
 # Enable the serde en/decoders for bincode or serde_json
 serde-bincode = ["heed-types/serde", "heed-types/bincode"]

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -246,10 +246,10 @@ impl EnvOpenOptions {
                         mdb_result(ffi::mdb_env_set_maxdbs(env, dbs))?;
                     }
 
-                    // When the `send-read-txn` feature is enabled, we must force LMDB
+                    // When the `read-txn-no-tls` feature is enabled, we must force LMDB
                     // to avoid using the thread local storage, this way we allow users
                     // to use references of RoTxn between threads safely.
-                    let flags = if cfg!(feature = "send-read-txn") {
+                    let flags = if cfg!(feature = "read-txn-no-tls") {
                         self.flags | Flag::NoTls as u32
                     } else {
                         self.flags

--- a/heed/src/txn.rs
+++ b/heed/src/txn.rs
@@ -73,7 +73,7 @@ impl Drop for RoTxn<'_> {
     }
 }
 
-#[cfg(feature = "send-read-txn")]
+#[cfg(feature = "read-txn-no-tls")]
 unsafe impl Send for RoTxn<'_> {}
 
 fn abort_txn(txn: *mut ffi::MDB_txn) {


### PR DESCRIPTION
This pull request renames and document the `send-read-txn` into `read-txn-no-tls`. The renaming reason is that enabling this `MDB_NOTLS` `Env` flag also allows opening more than a single read transaction on a thread than just making it movable between threads.