### PR TITLE
Rename and document the `MDB_NOTLS` feature

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heed"
-version = "0.12.5"
+version = "0.12.7"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
 description = "A fully typed LMDB/MDBX wrapper with minimum overhead"
 license = "MIT"

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -35,10 +35,20 @@ url = "2.2.0"
 # like the `EnvOpenOptions` struct.
 default = ["lmdb", "serde", "serde-bincode", "serde-json"]
 
-# The NO_TLS flag is automatically set on Env opening and
-# RoTxn implements the Sync trait. This allow the user to reference
-# a read-only transaction from multiple threads at the same time.
-sync-read-txn = []
+# The #MDB_NOTLS flag is automatically set on Env opening and
+# RoTxn implements the Send trait. This allows the user to move
+# a RoTxn between threads as read transactions will no more use
+# thread local storage and will tie reader locktable slots to
+# #MDB_txn objects instead of to threads.
+#
+# According to the LMDB documentation, when this feature is not enabled:
+# A thread can only use one transaction at a time, plus any child
+# transactions. Each transaction belongs to one thread. [...]
+# The #MDB_NOTLS flag changes this for read-only transactions.
+#
+# And a #MDB_BAD_RSLOT error will be thrown when multiple read
+# transactions exists on the same thread
+read-txn-no-tls = []
 
 # Choose between using the MDBX key-value store or LMDB
 # MDBX is a fork of LMDB: https://github.com/erthink/libmdbx

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -193,10 +193,10 @@ impl EnvOpenOptions {
                         mdb_result(ffi::mdb_env_set_maxdbs(env, dbs))?;
                     }
 
-                    // When the `sync-read-txn` feature is enabled, we must force LMDB
+                    // When the `read-txn-no-tls` feature is enabled, we must force LMDB
                     // to avoid using the thread local storage, this way we allow users
                     // to use references of RoTxn between threads safely.
-                    let flags = if cfg!(feature = "sync-read-txn") {
+                    let flags = if cfg!(feature = "read-txn-no-tls") {
                         self.flags | Flags::MdbNoTls as u32
                     } else {
                         self.flags

--- a/heed/src/txn.rs
+++ b/heed/src/txn.rs
@@ -48,8 +48,8 @@ impl<T> Drop for RoTxn<'_, T> {
     }
 }
 
-#[cfg(feature = "sync-read-txn")]
-unsafe impl<T> Sync for RoTxn<'_, T> {}
+#[cfg(feature = "read-txn-no-tls")]
+unsafe impl<T> Send for RoTxn<'_, T> {}
 
 #[cfg(all(feature = "lmdb", not(feature = "mdbx")))]
 fn abort_txn(txn: *mut ffi::MDB_txn) -> Result<()> {


### PR DESCRIPTION
This PR is the same as #192 combined with #193 and adapted to the v0.12 branch. Plus, it also bumps the version of heed to v0.12.7. (We were already using the v0.12.6, a tag was present on GitHub 😬).

I know it is technically a breaking change, but I don't want to move to v0.13, and we are the only ones at Meilisearch using this specific branch. It is not published on crates.io.