### PR TITLE
Add `rmp-serde` support to heed-types.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,9 @@ jobs:
       - name: Run the examples
         run: |
           cargo clean
-          cargo run --example 2>&1 | grep -E '^ ' | xargs -n1 cargo run --example
+          # rmp-serde needs a feature activated, so we'll just run it separately.
+          cargo run --example 2>&1 | grep -E '^ ' | awk '!/rmp-serde/' | xargs -n1 cargo run --example
+          cargo run --example rmp-serde --features serde-rmp
 
   fmt:
     name: Ensure the heed project is formatted

--- a/heed-types/Cargo.toml
+++ b/heed-types/Cargo.toml
@@ -24,7 +24,7 @@ rmp-serde = { version = "1.1.2", optional = true }
 rand = "0.8.5"
 
 [features]
-default = ["serde-bincode", "serde-json", "serde-rmp"]
+default = ["serde-bincode", "serde-json"]
 serde-bincode = ["serde", "bincode"]
 serde-json = ["serde", "serde_json"]
 serde-rmp = ["serde", "rmp-serde"]

--- a/heed-types/Cargo.toml
+++ b/heed-types/Cargo.toml
@@ -18,14 +18,16 @@ byteorder = "1.4.3"
 heed-traits = { version = "0.20.0-alpha.4", path = "../heed-traits" }
 serde = { version = "1.0.151", optional = true }
 serde_json = { version = "1.0.91", optional = true }
+rmp-serde = { version = "1.1.2", optional = true }
 
 [dev-dependencies]
 rand = "0.8.5"
 
 [features]
-default = ["serde-bincode", "serde-json"]
+default = ["serde-bincode", "serde-json", "serde-rmp"]
 serde-bincode = ["serde", "bincode"]
 serde-json = ["serde", "serde_json"]
+serde-rmp = ["serde", "rmp-serde"]
 # serde_json features
 preserve_order = ["serde_json/preserve_order"]
 arbitrary_precision = ["serde_json/arbitrary_precision"]

--- a/heed-types/src/lib.rs
+++ b/heed-types/src/lib.rs
@@ -4,7 +4,7 @@
 //! For specific types you can choose:
 //!   - [`Str`] to store [`str`](primitive@str)s
 //!   - [`Unit`] to store `()` types
-//!   - [`SerdeBincode`] or [`SerdeJson`] to store [`Serialize`]/[`Deserialize`] types
+//!   - [`SerdeBincode`],  [`SerdeJson`], or [`SerdeRmp`] to store [`Serialize`]/[`Deserialize`] types
 //!
 //! But if you want to store big types that can be efficiently deserialized then
 //! here is a little table to help you in your quest:
@@ -39,6 +39,9 @@ mod serde_bincode;
 
 #[cfg(feature = "serde-json")]
 mod serde_json;
+
+#[cfg(feature = "serde-rmp")]
+mod serde_rmp;
 
 use heed_traits::BoxedError;
 
@@ -77,3 +80,5 @@ impl heed_traits::BytesDecode<'_> for DecodeIgnore {
 pub use self::serde_bincode::SerdeBincode;
 #[cfg(feature = "serde-json")]
 pub use self::serde_json::SerdeJson;
+#[cfg(feature = "serde-rmp")]
+pub use self::serde_rmp::SerdeRmp;

--- a/heed-types/src/serde_rmp.rs
+++ b/heed-types/src/serde_rmp.rs
@@ -1,0 +1,35 @@
+use std::borrow::Cow;
+
+use heed_traits::{BoxedError, BytesDecode, BytesEncode};
+use serde::{Deserialize, Serialize};
+
+/// Describes a type that is [`Serialize`]/[`Deserialize`] and uses `rmp_serde` to do so.
+///
+/// It can borrow bytes from the original slice.
+pub struct SerdeRmp<T>(std::marker::PhantomData<T>);
+
+impl<'a, T: 'a> BytesEncode<'a> for SerdeRmp<T>
+where
+    T: Serialize,
+{
+    type EItem = T;
+
+    fn bytes_encode(item: &Self::EItem) -> Result<Cow<[u8]>, BoxedError> {
+        rmp_serde::to_vec(item).map(Cow::Owned).map_err(Into::into)
+    }
+}
+
+impl<'a, T: 'a> BytesDecode<'a> for SerdeRmp<T>
+where
+    T: Deserialize<'a>,
+{
+    type DItem = T;
+
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
+        rmp_serde::from_slice(bytes).map_err(Into::into)
+    }
+}
+
+unsafe impl<T> Send for SerdeRmp<T> {}
+
+unsafe impl<T> Sync for SerdeRmp<T> {}

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -74,3 +74,4 @@ posix-sem = ["lmdb-master-sys/posix-sem"]
 [[example]]
 name = "rmp-serde"
 required-features = ["serde-rmp"]
+

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -51,9 +51,10 @@ default = ["serde", "serde-bincode", "serde-json"]
 # transactions exists on the same thread
 read-txn-no-tls = []
 
-# Enable the serde en/decoders for bincode or serde_json
+# Enable the serde en/decoders for bincode, serde_json, or rmp_serde
 serde-bincode = ["heed-types/serde", "heed-types/bincode"]
 serde-json = ["heed-types/serde", "heed-types/serde-json"]
+serde-rmp = ["heed-types/serde", "heed-types/serde-rmp"]
 
 # serde_json features
 preserve_order = ["heed-types/preserve_order"]
@@ -69,3 +70,7 @@ unbounded_depth = ["heed-types/unbounded_depth"]
 # should look into before enabling this feature. Also, see here:
 # <https://github.com/LMDB/lmdb/blob/3947014aed7ffe39a79991fa7fb5b234da47ad1a/libraries/liblmdb/lmdb.h#L46-L69>
 posix-sem = ["lmdb-master-sys/posix-sem"]
+
+[[example]]
+name = "rmp-serde"
+required-features = ["serde-rmp"]

--- a/heed/examples/rmp-serde.rs
+++ b/heed/examples/rmp-serde.rs
@@ -6,7 +6,6 @@ use heed::types::{SerdeRmp, Str};
 use heed::{Database, EnvOpenOptions};
 use serde::{Deserialize, Serialize};
 
-
 fn main() -> Result<(), Box<dyn Error>> {
     let path = Path::new("target").join("heed.mdb");
 

--- a/heed/examples/rmp-serde.rs
+++ b/heed/examples/rmp-serde.rs
@@ -1,0 +1,41 @@
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+use heed::bytemuck::{Pod, Zeroable};
+use heed::byteorder::BE;
+use heed::types::*;
+use heed::{Database, EnvOpenOptions};
+use serde::{Deserialize, Serialize};
+
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let path = Path::new("target").join("heed.mdb");
+
+    fs::create_dir_all(&path)?;
+
+    let env = EnvOpenOptions::new()
+        .map_size(10 * 1024 * 1024) // 10MB
+        .max_dbs(3000)
+        .open(path)?;
+
+    // you can specify that a database will support some typed key/data
+    // serde types are also supported!!!
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Hello<'a> {
+        string: &'a str,
+    }
+
+    let mut wtxn = env.write_txn()?;
+    let db: Database<Str, SerdeRmp<Hello>> = env.create_database(&mut wtxn, Some("serde-rmp"))?;
+
+    let hello = Hello { string: "hi" };
+    db.put(&mut wtxn, "hello", &hello)?;
+
+    let ret: Option<Hello> = db.get(&wtxn, "hello")?;
+    println!("serde-rmp:\t{:?}", ret);
+
+    wtxn.commit()?;
+
+    Ok(())
+}

--- a/heed/examples/rmp-serde.rs
+++ b/heed/examples/rmp-serde.rs
@@ -2,9 +2,7 @@ use std::error::Error;
 use std::fs;
 use std::path::Path;
 
-use heed::bytemuck::{Pod, Zeroable};
-use heed::byteorder::BE;
-use heed::types::*;
+use heed::types::{SerdeRmp, Str};
 use heed::{Database, EnvOpenOptions};
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
# Pull Request

## Related issue
None, afaict.

## What does this PR do?
- Expose a utility struct that represents data that can be serialized and deserialized with [`rmp-serde`](https://github.com/3Hren/msgpack-rust/tree/master/rmp-serde).

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
