### PR TITLE
Expose a function to get the underlying LMDB library version

### DIFF
--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -6,7 +6,7 @@ pub use ffi::{
     mdb_env_get_fd, mdb_env_get_flags, mdb_env_info, mdb_env_open, mdb_env_set_mapsize,
     mdb_env_set_maxdbs, mdb_env_set_maxreaders, mdb_env_stat, mdb_env_sync, mdb_filehandle_t,
     mdb_get, mdb_put, mdb_reader_check, mdb_stat, mdb_txn_abort, mdb_txn_begin, mdb_txn_commit,
-    MDB_cursor, MDB_dbi, MDB_env, MDB_envinfo, MDB_stat, MDB_txn, MDB_val, MDB_APPEND,
+    mdb_version, MDB_cursor, MDB_dbi, MDB_env, MDB_envinfo, MDB_stat, MDB_txn, MDB_val, MDB_APPEND,
     MDB_CP_COMPACT, MDB_CREATE, MDB_CURRENT, MDB_RDONLY, MDB_RESERVE,
 };
 use lmdb_master_sys as ffi;


### PR DESCRIPTION
This PR closes #201 and fixes #199. It exposes a function that returns the LMDB library version used by heed.