### PR TITLE
Support customized key compare function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["lmdb-master-sys", "heed", "heed-traits", "heed-types"]
+resolver = "2"

--- a/heed-traits/src/lib.rs
+++ b/heed-traits/src/lib.rs
@@ -60,18 +60,28 @@ pub trait LexicographicComparator: Comparator {
     /// This function must never crash.
     fn compare_elem(a: u8, b: u8) -> Ordering;
 
-    /// Update `bytes` to its immediate successor.
-    fn advance(bytes: &mut Vec<u8>);
+    /// Advances the given `elem` to its immediate lexicographic successor, if possible.
+    /// Returns `None` if `elem` is already at its maximum value with respect to the
+    /// lexicographic order defined by this comparator.
+    fn advance(elem: u8) -> Option<u8>;
 
-    /// Update `bytes` to its immediate predecessor.
-    fn retreat(bytes: &mut Vec<u8>);
+    /// Moves the given `elem` to its immediate lexicographic predecessor, if possible.
+    /// Returns `None` if `elem` is already at its minimum value with respect to the
+    /// lexicographic order defined by this comparator.
+    fn retreat(elem: u8) -> Option<u8>;
+
+    /// Returns the maximum byte value per the comparator's lexicographic order.
+    fn max_elem() -> u8;
+
+    /// Returns the minimum byte value per the comparator's lexicographic order.
+    fn min_elem() -> u8;
 }
 
 impl<C: LexicographicComparator> Comparator for C {
     fn compare(a: &[u8], b: &[u8]) -> Ordering {
         for idx in 0..std::cmp::min(a.len(), b.len()) {
             if a[idx] != b[idx] {
-                return a[idx].cmp(&b[idx]);
+                return C::compare_elem(a[idx], b[idx]);
             }
         }
         a.len().cmp(&b.len())

--- a/heed-traits/src/lib.rs
+++ b/heed-traits/src/lib.rs
@@ -3,7 +3,7 @@
 #![warn(missing_docs)]
 
 use std::borrow::Cow;
-use std::cmp::Ordering;
+use std::cmp::{Ord, Ordering};
 use std::error::Error as StdError;
 
 /// A boxed `Send + Sync + 'static` error.
@@ -63,12 +63,12 @@ pub trait LexicographicComparator: Comparator {
     /// Advances the given `elem` to its immediate lexicographic successor, if possible.
     /// Returns `None` if `elem` is already at its maximum value with respect to the
     /// lexicographic order defined by this comparator.
-    fn advance(elem: u8) -> Option<u8>;
+    fn successor(elem: u8) -> Option<u8>;
 
     /// Moves the given `elem` to its immediate lexicographic predecessor, if possible.
     /// Returns `None` if `elem` is already at its minimum value with respect to the
     /// lexicographic order defined by this comparator.
-    fn retreat(elem: u8) -> Option<u8>;
+    fn predecessor(elem: u8) -> Option<u8>;
 
     /// Returns the maximum byte value per the comparator's lexicographic order.
     fn max_elem() -> u8;
@@ -84,6 +84,6 @@ impl<C: LexicographicComparator> Comparator for C {
                 return C::compare_elem(a[idx], b[idx]);
             }
         }
-        a.len().cmp(&b.len())
+        Ord::cmp(&a.len(), &b.len())
     }
 }

--- a/heed/examples/custom_comparator.rs
+++ b/heed/examples/custom_comparator.rs
@@ -1,0 +1,61 @@
+use std::cmp::Ordering;
+use std::error::Error;
+use std::path::Path;
+use std::{fs, str};
+
+use heed::EnvOpenOptions;
+use heed_traits::Comparator;
+use heed_types::{Str, Unit};
+
+struct StringAsIntCmp;
+
+// This function takes two strings which represent positive numbers,
+// parses them into i32s and compare the parsed value.
+// Therefore "-1000" < "-100" must be true even without '0' padding.
+impl Comparator for StringAsIntCmp {
+    fn compare(a: &[u8], b: &[u8]) -> Ordering {
+        let a: i32 = str::from_utf8(a).unwrap().parse().unwrap();
+        let b: i32 = str::from_utf8(b).unwrap().parse().unwrap();
+        a.cmp(&b)
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let env_path = Path::new("target").join("custom-key-cmp.mdb");
+
+    let _ = fs::remove_dir_all(&env_path);
+
+    fs::create_dir_all(&env_path)?;
+    let env = EnvOpenOptions::new()
+        .map_size(10 * 1024 * 1024) // 10MB
+        .max_dbs(3)
+        .open(env_path)?;
+
+    let mut wtxn = env.write_txn()?;
+    let db = env
+        .database_options()
+        .types::<Str, Unit>()
+        .comparator::<StringAsIntCmp>()
+        .create(&mut wtxn)?;
+    wtxn.commit()?;
+
+    let mut wtxn = env.write_txn()?;
+
+    // We fill our database with entries.
+    db.put(&mut wtxn, "-100000", &())?;
+    db.put(&mut wtxn, "-10000", &())?;
+    db.put(&mut wtxn, "-1000", &())?;
+    db.put(&mut wtxn, "-100", &())?;
+    db.put(&mut wtxn, "100", &())?;
+
+    // We check that the key are in the right order ("-100" < "-1000" < "-10000"...)
+    let mut iter = db.iter(&wtxn)?;
+    assert_eq!(iter.next().transpose()?, Some(("-100000", ())));
+    assert_eq!(iter.next().transpose()?, Some(("-10000", ())));
+    assert_eq!(iter.next().transpose()?, Some(("-1000", ())));
+    assert_eq!(iter.next().transpose()?, Some(("-100", ())));
+    assert_eq!(iter.next().transpose()?, Some(("100", ())));
+    drop(iter);
+
+    Ok(())
+}

--- a/heed/examples/custom_comparator.rs
+++ b/heed/examples/custom_comparator.rs
@@ -7,7 +7,7 @@ use heed::EnvOpenOptions;
 use heed_traits::Comparator;
 use heed_types::{Str, Unit};
 
-struct StringAsIntCmp;
+enum StringAsIntCmp {}
 
 // This function takes two strings which represent positive numbers,
 // parses them into i32s and compare the parsed value.
@@ -35,7 +35,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let db = env
         .database_options()
         .types::<Str, Unit>()
-        .comparator::<StringAsIntCmp>()
+        .key_comparator::<StringAsIntCmp>()
         .create(&mut wtxn)?;
     wtxn.commit()?;
 

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -7,7 +7,7 @@ use heed_traits::{Comparator, LexicographicComparator};
 use types::{DecodeIgnore, LazyDecode};
 
 use crate::cursor::MoveOperation;
-use crate::env::NoopComparator;
+use crate::env::DefaultComparator;
 use crate::iteration_method::MoveOnCurrentKeyDuplicates;
 use crate::mdb::error::mdb_result;
 use crate::mdb::ffi;
@@ -61,7 +61,7 @@ pub struct DatabaseOpenOptions<'e, KC, DC, C> {
     flags: AllDatabaseFlags,
 }
 
-impl<'e> DatabaseOpenOptions<'e, Unspecified, Unspecified, Unspecified> {
+impl<'e> DatabaseOpenOptions<'e, Unspecified, Unspecified, DefaultComparator> {
     /// Create an options struct to open/create a database with specific flags.
     pub fn new(env: &'e Env) -> Self {
         DatabaseOpenOptions {
@@ -78,7 +78,7 @@ impl<'e, KC, DC, C> DatabaseOpenOptions<'e, KC, DC, C> {
     ///
     /// The default types are [`Unspecified`] and require a call to [`Database::remap_types`]
     /// to use the [`Database`].
-    pub fn types<NKC, NDC>(self) -> DatabaseOpenOptions<'e, NKC, NDC, NoopComparator> {
+    pub fn types<NKC, NDC>(self) -> DatabaseOpenOptions<'e, NKC, NDC, DefaultComparator> {
         DatabaseOpenOptions {
             env: self.env,
             types: Default::default(),
@@ -89,7 +89,7 @@ impl<'e, KC, DC, C> DatabaseOpenOptions<'e, KC, DC, C> {
     /// Change the customized key compare function of the database.
     ///
     /// By default no customized compare function will be set when opening a database.
-    pub fn comparator<NC>(self) -> DatabaseOpenOptions<'e, KC, DC, NC> {
+    pub fn key_comparator<NC>(self) -> DatabaseOpenOptions<'e, KC, DC, NC> {
         DatabaseOpenOptions {
             env: self.env,
             types: Default::default(),
@@ -284,7 +284,7 @@ impl<'e, KC, DC, C> DatabaseOpenOptions<'e, KC, DC, C> {
 /// wtxn.commit()?;
 /// # Ok(()) }
 /// ```
-pub struct Database<KC, DC, C = NoopComparator> {
+pub struct Database<KC, DC, C = DefaultComparator> {
     pub(crate) env_ident: usize,
     pub(crate) dbi: ffi::MDB_dbi,
     marker: marker::PhantomData<(KC, DC, C)>,

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -356,25 +356,35 @@ extern "C" fn custom_key_cmp_wrapper<C: Comparator>(
 pub struct NoopComparator;
 
 impl LexicographicComparator for NoopComparator {
+    #[inline]
     fn compare_elem(a: u8, b: u8) -> Ordering {
         a.cmp(&b)
     }
 
-    fn advance(bytes: &mut Vec<u8>) {
-        match bytes.last_mut() {
-            Some(&mut 255) | None => bytes.push(0),
-            Some(last) => *last += 1,
+    #[inline]
+    fn advance(elem: u8) -> Option<u8> {
+        match elem {
+            u8::MAX => None,
+            elem => Some(elem + 1),
         }
     }
 
-    fn retreat(bytes: &mut Vec<u8>) {
-        match bytes.last_mut() {
-            Some(&mut 0) => {
-                bytes.pop();
-            }
-            Some(last) => *last -= 1,
-            None => panic!("Vec is empty and must not be"),
+    #[inline]
+    fn retreat(elem: u8) -> Option<u8> {
+        match elem {
+            u8::MIN => None,
+            elem => Some(elem - 1),
         }
+    }
+
+    #[inline]
+    fn max_elem() -> u8 {
+        u8::MAX
+    }
+
+    #[inline]
+    fn min_elem() -> u8 {
+        u8::MIN
     }
 }
 

--- a/heed/src/iterator/mod.rs
+++ b/heed/src/iterator/mod.rs
@@ -6,23 +6,6 @@ pub use self::iter::{RoIter, RoRevIter, RwIter, RwRevIter};
 pub use self::prefix::{RoPrefix, RoRevPrefix, RwPrefix, RwRevPrefix};
 pub use self::range::{RoRange, RoRevRange, RwRange, RwRevRange};
 
-fn advance_key(bytes: &mut Vec<u8>) {
-    match bytes.last_mut() {
-        Some(&mut 255) | None => bytes.push(0),
-        Some(last) => *last += 1,
-    }
-}
-
-fn retreat_key(bytes: &mut Vec<u8>) {
-    match bytes.last_mut() {
-        Some(&mut 0) => {
-            bytes.pop();
-        }
-        Some(last) => *last -= 1,
-        None => panic!("Vec is empty and must not be"),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/heed/src/iterator/mod.rs
+++ b/heed/src/iterator/mod.rs
@@ -8,8 +8,10 @@ pub use self::range::{RoRange, RoRevRange, RwRange, RwRevRange};
 
 #[cfg(test)]
 mod tests {
+    use std::ops;
+
     #[test]
-    fn prefix_iter_with_byte_255() {
+    fn prefix_iter_last_with_byte_255() {
         use crate::types::*;
         use crate::EnvOpenOptions;
 
@@ -31,6 +33,18 @@ mod tests {
         db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], "world").unwrap();
         db.put(&mut wtxn, &[0, 0, 1, 0, 119, 111, 114, 108, 100], "world").unwrap();
 
+        db.put(&mut wtxn, &[255, 255, 0, 254, 119, 111, 114, 108, 100], "world").unwrap();
+        db.put(&mut wtxn, &[255, 255, 0, 255, 104, 101, 108, 108, 111], "hello").unwrap();
+        db.put(&mut wtxn, &[255, 255, 0, 255, 119, 111, 114, 108, 100], "world").unwrap();
+        db.put(&mut wtxn, &[255, 255, 1, 0, 119, 111, 114, 108, 100], "world").unwrap();
+
+        // Lets check that we properly get the last entry.
+        let iter = db.prefix_iter(&wtxn, &[0, 0, 0, 255]).unwrap();
+        assert_eq!(
+            iter.last().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], "world"))
+        );
+
         // Lets check that we can prefix_iter on that sequence with the key "255".
         let mut iter = db.prefix_iter(&wtxn, &[0, 0, 0, 255]).unwrap();
         assert_eq!(
@@ -40,6 +54,34 @@ mod tests {
         assert_eq!(
             iter.next().transpose().unwrap(),
             Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], "world"))
+        );
+        assert_eq!(iter.next().transpose().unwrap(), None);
+        drop(iter);
+
+        // Lets check that we properly get the last entry.
+        let iter = db.prefix_iter(&wtxn, &[255]).unwrap();
+        assert_eq!(
+            iter.last().transpose().unwrap(),
+            Some((&[255, 255, 1, 0, 119, 111, 114, 108, 100][..], "world"))
+        );
+
+        // Lets check that we can prefix_iter on that sequence with the key "255".
+        let mut iter = db.prefix_iter(&wtxn, &[255]).unwrap();
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[255, 255, 0, 254, 119, 111, 114, 108, 100][..], "world"))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[255, 255, 0, 255, 104, 101, 108, 108, 111][..], "hello"))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[255, 255, 0, 255, 119, 111, 114, 108, 100][..], "world"))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[255, 255, 1, 0, 119, 111, 114, 108, 100][..], "world"))
         );
         assert_eq!(iter.next().transpose().unwrap(), None);
         drop(iter);
@@ -209,6 +251,54 @@ mod tests {
     }
 
     #[test]
+    fn range_iter_last_with_byte_255() {
+        use crate::types::*;
+        use crate::EnvOpenOptions;
+
+        let dir = tempfile::tempdir().unwrap();
+        let env = EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024) // 10MB
+            .max_dbs(3000)
+            .open(dir.path())
+            .unwrap();
+
+        let mut wtxn = env.write_txn().unwrap();
+        let db = env.create_database::<ByteSlice, Unit>(&mut wtxn, None).unwrap();
+        wtxn.commit().unwrap();
+
+        // Create an ordered list of keys...
+        let mut wtxn = env.write_txn().unwrap();
+        db.put(&mut wtxn, &[0, 0, 0], &()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 1], &()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 2], &()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 1, 0], &()).unwrap();
+
+        // Lets check that we properly get the last entry.
+        let iter = db
+            .range(
+                &wtxn,
+                &(ops::Bound::Excluded(&[0, 0, 0][..]), ops::Bound::Included(&[0, 0, 1, 0][..])),
+            )
+            .unwrap();
+        assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 1, 0][..], ())));
+
+        // Lets check that we can range_iter on that sequence with the key "255".
+        let mut iter = db
+            .range(
+                &wtxn,
+                &(ops::Bound::Excluded(&[0, 0, 0][..]), ops::Bound::Included(&[0, 0, 1, 0][..])),
+            )
+            .unwrap();
+        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 1][..], ())));
+        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 2][..], ())));
+        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 1, 0][..], ())));
+        assert_eq!(iter.next().transpose().unwrap(), None);
+        drop(iter);
+
+        wtxn.abort();
+    }
+
+    #[test]
     fn prefix_iter_last() {
         use crate::types::*;
         use crate::EnvOpenOptions;
@@ -359,6 +449,75 @@ mod tests {
     }
 
     #[test]
+    fn rev_prefix_iter_last_with_byte_255() {
+        use crate::types::*;
+        use crate::EnvOpenOptions;
+
+        let dir = tempfile::tempdir().unwrap();
+        let env = EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024) // 10MB
+            .max_dbs(3000)
+            .open(dir.path())
+            .unwrap();
+
+        let mut wtxn = env.write_txn().unwrap();
+        let db = env.create_database::<ByteSlice, Unit>(&mut wtxn, None).unwrap();
+        wtxn.commit().unwrap();
+
+        // Create an ordered list of keys...
+        let mut wtxn = env.write_txn().unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 254, 119, 111, 114, 108, 100], &()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 255, 104, 101, 108, 108, 111], &()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 255, 119, 111, 114, 108, 100], &()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 1, 0, 119, 111, 114, 108, 100], &()).unwrap();
+
+        db.put(&mut wtxn, &[255, 255, 0, 254, 119, 111, 114, 108, 100], &()).unwrap();
+        db.put(&mut wtxn, &[255, 255, 0, 255, 104, 101, 108, 108, 111], &()).unwrap();
+        db.put(&mut wtxn, &[255, 255, 0, 255, 119, 111, 114, 108, 100], &()).unwrap();
+        db.put(&mut wtxn, &[255, 255, 1, 0, 119, 111, 114, 108, 100], &()).unwrap();
+
+        // Lets check that we can get last entry on that sequence ending with the key "255".
+        let iter = db.rev_prefix_iter(&wtxn, &[0, 0, 0, 255]).unwrap();
+        assert_eq!(
+            iter.last().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ()))
+        );
+
+        // Lets check that we can prefix_iter on that sequence ending with the key "255".
+        let mut iter = db.rev_prefix_iter(&wtxn, &[0, 0, 0, 255]).unwrap();
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 119, 111, 114, 108, 100][..], ()))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[0, 0, 0, 255, 104, 101, 108, 108, 111][..], ()))
+        );
+        assert_eq!(iter.last().transpose().unwrap(), None);
+
+        let mut iter = db.rev_prefix_iter(&wtxn, &[255, 255]).unwrap();
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[255, 255, 1, 0, 119, 111, 114, 108, 100][..], ()))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[255, 255, 0, 255, 119, 111, 114, 108, 100][..], ()))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[255, 255, 0, 255, 104, 101, 108, 108, 111][..], ()))
+        );
+        assert_eq!(
+            iter.next().transpose().unwrap(),
+            Some((&[255, 255, 0, 254, 119, 111, 114, 108, 100][..], ()))
+        );
+        assert_eq!(iter.last().transpose().unwrap(), None);
+
+        wtxn.abort();
+    }
+
+    #[test]
     fn rev_range_iter_last() {
         use crate::byteorder::BigEndian;
         use crate::types::*;
@@ -406,6 +565,54 @@ mod tests {
         let mut iter = db.rev_range(&wtxn, &(4..=4)).unwrap();
         assert_eq!(iter.next().transpose().unwrap(), Some((4, ())));
         assert_eq!(iter.last().transpose().unwrap(), None);
+
+        wtxn.abort();
+    }
+
+    #[test]
+    fn rev_range_iter_last_with_byte_255() {
+        use crate::types::*;
+        use crate::EnvOpenOptions;
+
+        let dir = tempfile::tempdir().unwrap();
+        let env = EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024) // 10MB
+            .max_dbs(3000)
+            .open(dir.path())
+            .unwrap();
+
+        let mut wtxn = env.write_txn().unwrap();
+        let db = env.create_database::<ByteSlice, Unit>(&mut wtxn, None).unwrap();
+        wtxn.commit().unwrap();
+
+        // Create an ordered list of keys...
+        let mut wtxn = env.write_txn().unwrap();
+        db.put(&mut wtxn, &[0, 0, 0], &()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 1], &()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 0, 2], &()).unwrap();
+        db.put(&mut wtxn, &[0, 0, 1, 0], &()).unwrap();
+
+        // Lets check that we properly get the last entry.
+        let iter = db
+            .rev_range(
+                &wtxn,
+                &(ops::Bound::Excluded(&[0, 0, 0][..]), ops::Bound::Included(&[0, 0, 1, 0][..])),
+            )
+            .unwrap();
+        assert_eq!(iter.last().transpose().unwrap(), Some((&[0, 0, 0, 1][..], ())));
+
+        // Lets check that we can range_iter on that sequence with the key "255".
+        let mut iter = db
+            .rev_range(
+                &wtxn,
+                &(ops::Bound::Excluded(&[0, 0, 0][..]), ops::Bound::Included(&[0, 0, 1, 0][..])),
+            )
+            .unwrap();
+        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 1, 0][..], ())));
+        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 2][..], ())));
+        assert_eq!(iter.next().transpose().unwrap(), Some((&[0, 0, 0, 1][..], ())));
+        assert_eq!(iter.next().transpose().unwrap(), None);
+        drop(iter);
 
         wtxn.abort();
     }

--- a/heed/src/iterator/prefix.rs
+++ b/heed/src/iterator/prefix.rs
@@ -5,7 +5,7 @@ use heed_traits::LexicographicComparator;
 use types::LazyDecode;
 
 use crate::cursor::MoveOperation;
-use crate::env::NoopComparator;
+use crate::env::DefaultComparator;
 use crate::iteration_method::{IterationMethod, MoveBetweenKeys, MoveThroughDuplicateValues};
 use crate::*;
 
@@ -21,7 +21,7 @@ fn advance_prefix<C: LexicographicComparator>(bytes: &mut Vec<u8>) -> bool {
     if idx == 0 {
         return false;
     }
-    bytes[idx - 1] = C::advance(bytes[idx - 1]).expect("Cannot advance byte; this is a bug.");
+    bytes[idx - 1] = C::successor(bytes[idx - 1]).expect("Cannot advance byte; this is a bug.");
     for i in (idx + 1)..=bytes.len() {
         bytes[i - 1] = C::min_elem();
     }
@@ -40,7 +40,7 @@ fn retreat_prefix<C: LexicographicComparator>(bytes: &mut Vec<u8>) -> bool {
     if idx == 0 {
         return false;
     }
-    bytes[idx - 1] = C::retreat(bytes[idx - 1]).expect("Cannot retreat byte; this is a bug.");
+    bytes[idx - 1] = C::predecessor(bytes[idx - 1]).expect("Cannot retreat byte; this is a bug.");
     for i in (idx + 1)..=bytes.len() {
         bytes[i - 1] = C::max_elem();
     }
@@ -64,7 +64,7 @@ fn move_on_prefix_end<'txn, C: LexicographicComparator>(
 }
 
 /// A read-only prefix iterator structure.
-pub struct RoPrefix<'txn, KC, DC, C = NoopComparator, IM = MoveThroughDuplicateValues> {
+pub struct RoPrefix<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {
     cursor: RoCursor<'txn>,
     prefix: Vec<u8>,
     move_on_first: bool,
@@ -201,7 +201,7 @@ impl<KC, DC, C, IM> fmt::Debug for RoPrefix<'_, KC, DC, C, IM> {
 }
 
 /// A read-write prefix iterator structure.
-pub struct RwPrefix<'txn, KC, DC, C = NoopComparator, IM = MoveThroughDuplicateValues> {
+pub struct RwPrefix<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {
     cursor: RwCursor<'txn>,
     prefix: Vec<u8>,
     move_on_first: bool,
@@ -451,7 +451,7 @@ impl<KC, DC, C, IM> fmt::Debug for RwPrefix<'_, KC, DC, C, IM> {
 }
 
 /// A reverse read-only prefix iterator structure.
-pub struct RoRevPrefix<'txn, KC, DC, C = NoopComparator, IM = MoveThroughDuplicateValues> {
+pub struct RoRevPrefix<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {
     cursor: RoCursor<'txn>,
     prefix: Vec<u8>,
     move_on_last: bool,
@@ -587,7 +587,7 @@ impl<KC, DC, C, IM> fmt::Debug for RoRevPrefix<'_, KC, DC, C, IM> {
 }
 
 /// A reverse read-write prefix iterator structure.
-pub struct RwRevPrefix<'txn, KC, DC, C = NoopComparator, IM = MoveThroughDuplicateValues> {
+pub struct RwRevPrefix<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {
     cursor: RwCursor<'txn>,
     prefix: Vec<u8>,
     move_on_last: bool,

--- a/heed/src/iterator/range.rs
+++ b/heed/src/iterator/range.rs
@@ -4,7 +4,6 @@ use std::ops::Bound;
 
 use types::LazyDecode;
 
-use super::{advance_key, retreat_key};
 use crate::cursor::MoveOperation;
 use crate::iteration_method::{IterationMethod, MoveBetweenKeys, MoveThroughDuplicateValues};
 use crate::*;
@@ -32,12 +31,13 @@ fn move_on_range_start<'txn>(
 ) -> Result<Option<(&'txn [u8], &'txn [u8])>> {
     match start_bound {
         Bound::Included(start) => cursor.move_on_key_greater_than_or_equal_to(start),
-        Bound::Excluded(start) => {
-            advance_key(start);
-            let result = cursor.move_on_key_greater_than_or_equal_to(start);
-            retreat_key(start);
-            result
-        }
+        Bound::Excluded(start) => match cursor.move_on_key_greater_than_or_equal_to(start)? {
+            Some((key, _)) if key == start => {
+                cursor.move_on_next(MoveOperation::NoDup)?;
+                cursor.move_on_prev(MoveOperation::NoDup)
+            }
+            result => Ok(result),
+        },
         Bound::Unbounded => cursor.move_on_first(MoveOperation::NoDup),
     }
 }

--- a/heed/src/iterator/range.rs
+++ b/heed/src/iterator/range.rs
@@ -32,10 +32,7 @@ fn move_on_range_start<'txn>(
     match start_bound {
         Bound::Included(start) => cursor.move_on_key_greater_than_or_equal_to(start),
         Bound::Excluded(start) => match cursor.move_on_key_greater_than_or_equal_to(start)? {
-            Some((key, _)) if key == start => {
-                cursor.move_on_next(MoveOperation::NoDup)?;
-                cursor.move_on_prev(MoveOperation::NoDup)
-            }
+            Some((key, _)) if key == start => cursor.move_on_next(MoveOperation::NoDup),
             result => Ok(result),
         },
         Bound::Unbounded => cursor.move_on_first(MoveOperation::NoDup),

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -5,10 +5,10 @@ pub use ffi::{
     mdb_dbi_close, mdb_dbi_open, mdb_del, mdb_drop, mdb_env_close, mdb_env_copyfd2, mdb_env_create,
     mdb_env_get_fd, mdb_env_get_flags, mdb_env_info, mdb_env_open, mdb_env_set_mapsize,
     mdb_env_set_maxdbs, mdb_env_set_maxreaders, mdb_env_stat, mdb_env_sync, mdb_filehandle_t,
-    mdb_get, mdb_put, mdb_reader_check, mdb_stat, mdb_txn_abort, mdb_txn_begin, mdb_txn_commit,
-    mdb_version, MDB_cursor, MDB_dbi, MDB_env, MDB_envinfo, MDB_stat, MDB_txn, MDB_val, MDB_APPEND,
-    MDB_APPENDDUP, MDB_CP_COMPACT, MDB_CREATE, MDB_CURRENT, MDB_DUPSORT, MDB_NODUPDATA,
-    MDB_NOOVERWRITE, MDB_RDONLY, MDB_RESERVE,
+    mdb_get, mdb_put, mdb_reader_check, mdb_set_compare, mdb_stat, mdb_txn_abort, mdb_txn_begin,
+    mdb_txn_commit, mdb_version, MDB_cursor, MDB_dbi, MDB_env, MDB_envinfo, MDB_stat, MDB_txn,
+    MDB_val, MDB_APPEND, MDB_APPENDDUP, MDB_CP_COMPACT, MDB_CREATE, MDB_CURRENT, MDB_DUPSORT,
+    MDB_NODUPDATA, MDB_NOOVERWRITE, MDB_RDONLY, MDB_RESERVE,
 };
 use lmdb_master_sys as ffi;
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #86 

## What does this PR do?

This PR continues the efforts in https://github.com/meilisearch/heed/pull/90 to allow users to customize key comparator. The implementation approaches stays mostly the same except the following parts

### Prefix iterator

`heed` implements the prefix iterator while `lmdb` does not actually have features like [prefix seek](https://github.com/facebook/rocksdb/wiki/Prefix-Seek) in rocksdb, which means all the logics that handles prefix are implemented in the rust wrapper layer.

After taking a closer look at the API of prefix iterator in `heed`, looks like currently `heed` has the following assumptions on the key order

1. For any `key` that starts with `prefix`, we have `prefix` < `key` unless `key` and `prefix` are identical.
2. If `prefix1` < `prefix2`, then for any `key1` that starts with `prefix1` and `key2` that starts with `prefix2`, we have `key1` < `key2`

These 2 assumptions together actually make the key order a lexicographic order, which I have a proof and can provide more details if needed. So on top of the `Comparator` trait, I also introduce a `LexicographicComparator` trait, and only when key order is lexicographic can users use the prefix iterator API.

### Database type

#86 mentions the attempt not to change the database type. In this PR, since I introduce the `LexicographicComparator`, I choose to add the comparator type as a generic type in `Database`'s definition, this brings the benefits that compile fails if a user is trying to use prefix iterator with a non-lexicographic comparator.

## Why do I need a custom key comparator?

Basically I am trying to implement a persistent key-ordered multimap on a bunch of storage engines. `LMDB` is faster than `rocksdb` with relatively small data volume so I'd love to add `LMDB` as an option for my multimap.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

@Kerollmops Since you are the author of the original PR and still an active committer in `heed`, I feel you must the be best person to take a look at this PR. I'd appreciate any feedback!

Thank you so much for contributing to Meilisearch!
