### PR TITLE
Remove useless `pkg_config` dependency

### DIFF
--- a/lmdb-master-sys/Cargo.toml
+++ b/lmdb-master-sys/Cargo.toml
@@ -30,7 +30,6 @@ libc = "0.2.139"
 bindgen = { version = "0.66.1", default-features = false, optional = true, features = ["runtime"] }
 cc = "1.0.78"
 doxygen-rs = "0.4.2"
-pkg-config = "0.3.26"
 
 [dev-dependencies]
 cstr = "0.2.11"

--- a/lmdb-master-sys/build.rs
+++ b/lmdb-master-sys/build.rs
@@ -1,5 +1,4 @@
 extern crate cc;
-extern crate pkg_config;
 
 #[cfg(feature = "bindgen")]
 extern crate bindgen;


### PR DESCRIPTION
The `pkg_config` dependency is no more used.