### PR TITLE
Re-export Comparator and LexicographicComparator traits

### DIFF
--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -76,7 +76,7 @@ pub use self::mdb::error::Error as MdbError;
 use self::mdb::ffi::{from_val, into_val};
 pub use self::mdb::flags::{DatabaseFlags, EnvFlags, PutFlags};
 pub use self::reserved_space::ReservedSpace;
-pub use self::traits::{BoxedError, BytesDecode, BytesEncode};
+pub use self::traits::{BoxedError, BytesDecode, BytesEncode, Comparator, LexicographicComparator};
 pub use self::txn::{RoTxn, RwTxn};
 
 /// The underlying LMDB library version information.


### PR DESCRIPTION
# Pull Request

## Related issue
A minor followup on https://github.com/meilisearch/heed/pull/212

## What does this PR do?
- Reexport 2 traits such that it'll be easier to use them; now I have to explicitly include `heed-traits` in my `Cargo.toml`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!

@Kerollmops I forgot this in my last PR, and didn't realize this until I started to use the new version of heed just now, haha
