### PR TITLE
Introduce the `remap` method on the `Lazy` type

### DIFF
--- a/heed-types/src/lazy_decode.rs
+++ b/heed-types/src/lazy_decode.rs
@@ -23,6 +23,11 @@ pub struct Lazy<'a, C> {
 }
 
 impl<'a, C: heed_traits::BytesDecode<'a>> Lazy<'a, C> {
+    /// Change the codec type of this database, specifying the new codec.
+    pub fn remap<NC>(&self) -> Lazy<'a, NC> {
+        Lazy { data: self.data, _phantom: marker::PhantomData }
+    }
+
     /// Decode the given bytes as DItem
     pub fn decode(&self) -> Result<C::DItem, BoxedError> {
         C::bytes_decode(self.data)

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -2153,7 +2153,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
         unsafe { mdb_result(ffi::mdb_drop(txn.txn.txn, self.dbi, 0)).map_err(Into::into) }
     }
 
-    /// Change the codec types of this uniform database, specifying the codecs.
+    /// Change the codec types of this database, specifying the codecs.
     ///
     /// # Safety
     ///
@@ -2197,12 +2197,12 @@ impl<KC, DC, C> Database<KC, DC, C> {
         Database::new(self.env_ident, self.dbi)
     }
 
-    /// Change the key codec type of this uniform database, specifying the new codec.
+    /// Change the key codec type of this database, specifying the new codec.
     pub fn remap_key_type<KC2>(&self) -> Database<KC2, DC, C> {
         self.remap_types::<KC2, DC>()
     }
 
-    /// Change the data codec type of this uniform database, specifying the new codec.
+    /// Change the data codec type of this database, specifying the new codec.
     pub fn remap_data_type<DC2>(&self) -> Database<KC, DC2, C> {
         self.remap_types::<KC, DC2>()
     }


### PR DESCRIPTION
This PR introduces a new method to change the codec of a `LazyDecode`d type. The `Lazy` type returned can be set to decode into another type on demand and doesn't consume the original `Lazy` type; Therefore, it can be first decoded into something to change the way it is effectively decoded later on.