### PR TITLE
Improve the `Rw*Iter::put_current` methods to be less restrictive

### DIFF
--- a/heed/examples/cursor-append.rs
+++ b/heed/examples/cursor-append.rs
@@ -29,9 +29,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // We try to append ordered entries in the second database.
     let mut iter = second.iter_mut(&mut wtxn)?;
 
-    unsafe { iter.put_current_with_flags(PutFlags::APPEND, "aaaa", "lol")? };
-    unsafe { iter.put_current_with_flags(PutFlags::APPEND, "abcd", "lol")? };
-    unsafe { iter.put_current_with_flags(PutFlags::APPEND, "bcde", "lol")? };
+    unsafe { iter.put_current_with_options::<Str>(PutFlags::APPEND, "aaaa", "lol")? };
+    unsafe { iter.put_current_with_options::<Str>(PutFlags::APPEND, "abcd", "lol")? };
+    unsafe { iter.put_current_with_options::<Str>(PutFlags::APPEND, "bcde", "lol")? };
 
     drop(iter);
 

--- a/heed/src/cursor.rs
+++ b/heed/src/cursor.rs
@@ -329,8 +329,9 @@ impl<'txn> RwCursor<'txn> {
     /// # Safety
     ///
     /// Please read the safety notes of the `[put_current]` method.
-    pub unsafe fn put_current_reserved<F>(
+    pub unsafe fn put_current_reserved_with_flags<F>(
         &mut self,
+        flags: PutFlags,
         key: &[u8],
         data_size: usize,
         mut write_func: F,
@@ -340,7 +341,7 @@ impl<'txn> RwCursor<'txn> {
     {
         let mut key_val = crate::into_val(key);
         let mut reserved = ffi::reserve_size_val(data_size);
-        let flags = ffi::MDB_RESERVE;
+        let flags = ffi::MDB_RESERVE | flags.bits();
 
         let result =
             mdb_result(ffi::mdb_cursor_put(self.cursor.cursor, &mut key_val, &mut reserved, flags));

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -2215,7 +2215,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
 
 impl<KC, DC, C> Clone for Database<KC, DC, C> {
     fn clone(&self) -> Database<KC, DC, C> {
-        Database { env_ident: self.env_ident, dbi: self.dbi, marker: marker::PhantomData }
+        *self
     }
 }
 

--- a/heed/src/iterator/iter.rs
+++ b/heed/src/iterator/iter.rs
@@ -299,7 +299,7 @@ impl<'txn, KC, DC, IM> RwIter<'txn, KC, DC, IM> {
         self.cursor.put_current_reserved(&key_bytes, data_size, write_func)
     }
 
-    /// Insert a key-value pair in this database. The entry is written with the specified flags.
+    /// Insert a key-value pair in this database. The entry is written with the specified flags and data codec.
     ///
     /// For more info, see [`RwIter::put_current_with_flags`].
     ///
@@ -316,33 +316,19 @@ impl<'txn, KC, DC, IM> RwIter<'txn, KC, DC, IM> {
     /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-    pub unsafe fn put_current_with_flags<'a>(
+    pub unsafe fn put_current_with_options<'a, NDC>(
         &mut self,
         flags: PutFlags,
         key: &'a KC::EItem,
-        data: &'a DC::EItem,
-    ) -> Result<()>
-    where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
-    {
-        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
-        let data_bytes: Cow<[u8]> = DC::bytes_encode(data).map_err(Error::Encoding)?;
-        self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
-    }
-
-    pub unsafe fn put_current_with_data_codec<'a, NDC>(
-        &mut self,
-        key: &'a KC::EItem,
         data: &'a NDC::EItem,
-    ) -> Result<bool>
+    ) -> Result<()>
     where
         KC: BytesEncode<'a>,
         NDC: BytesEncode<'a>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = NDC::bytes_encode(data).map_err(Error::Encoding)?;
-        self.cursor.put_current(&key_bytes, &data_bytes)
+        self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
     }
 
     /// Move on the first value of keys, ignoring duplicate values.
@@ -658,7 +644,7 @@ impl<'txn, KC, DC, IM> RwRevIter<'txn, KC, DC, IM> {
         self.cursor.put_current_reserved(&key_bytes, data_size, write_func)
     }
 
-    /// Insert a key-value pair in this database. The entry is written with the specified flags.
+    /// Insert a key-value pair in this database. The entry is written with the specified flags and data codec.
     ///
     /// For more info, see [`RwIter::put_current_with_flags`].
     ///
@@ -675,33 +661,19 @@ impl<'txn, KC, DC, IM> RwRevIter<'txn, KC, DC, IM> {
     /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-    pub unsafe fn put_current_with_flags<'a>(
+    pub unsafe fn put_current_with_options<'a, NDC>(
         &mut self,
         flags: PutFlags,
         key: &'a KC::EItem,
-        data: &'a DC::EItem,
-    ) -> Result<()>
-    where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
-    {
-        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
-        let data_bytes: Cow<[u8]> = DC::bytes_encode(data).map_err(Error::Encoding)?;
-        self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
-    }
-
-    pub unsafe fn put_current_with_data_codec<'a, NDC>(
-        &mut self,
-        key: &'a KC::EItem,
         data: &'a NDC::EItem,
-    ) -> Result<bool>
+    ) -> Result<()>
     where
         KC: BytesEncode<'a>,
         NDC: BytesEncode<'a>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = NDC::bytes_encode(data).map_err(Error::Encoding)?;
-        self.cursor.put_current(&key_bytes, &data_bytes)
+        self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
     }
 
     /// Move on the first value of keys, ignoring duplicate values.

--- a/heed/src/iterator/iter.rs
+++ b/heed/src/iterator/iter.rs
@@ -272,7 +272,7 @@ impl<'txn, KC, DC, IM> RwIter<'txn, KC, DC, IM> {
         self.cursor.put_current(&key_bytes, &data_bytes)
     }
 
-    /// Write a new value to the current entry.
+    /// Write a new value to the current entry. The entry is written with the specified flags.
     ///
     /// The given key **must** be equal to the one this cursor is pointing otherwise the database
     /// can be put into an inconsistent state.
@@ -285,8 +285,9 @@ impl<'txn, KC, DC, IM> RwIter<'txn, KC, DC, IM> {
     /// # Safety
     ///
     /// Please read the safety notes of the [`RwIter::put_current`] method.
-    pub unsafe fn put_current_reserved<'a, F>(
+    pub unsafe fn put_current_reserved_with_flags<'a, F>(
         &mut self,
+        flags: PutFlags,
         key: &'a KC::EItem,
         data_size: usize,
         write_func: F,
@@ -296,7 +297,7 @@ impl<'txn, KC, DC, IM> RwIter<'txn, KC, DC, IM> {
         F: FnMut(&mut ReservedSpace) -> io::Result<()>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
-        self.cursor.put_current_reserved(&key_bytes, data_size, write_func)
+        self.cursor.put_current_reserved_with_flags(flags, &key_bytes, data_size, write_func)
     }
 
     /// Insert a key-value pair in this database. The entry is written with the specified flags and data codec.
@@ -617,7 +618,7 @@ impl<'txn, KC, DC, IM> RwRevIter<'txn, KC, DC, IM> {
         self.cursor.put_current(&key_bytes, &data_bytes)
     }
 
-    /// Write a new value to the current entry.
+    /// Write a new value to the current entry. The entry is written with the specified flags.
     ///
     /// The given key **must** be equal to the one this cursor is pointing otherwise the database
     /// can be put into an inconsistent state.
@@ -630,8 +631,9 @@ impl<'txn, KC, DC, IM> RwRevIter<'txn, KC, DC, IM> {
     /// # Safety
     ///
     /// Please read the safety notes of the [`RwRevIter::put_current`] method.
-    pub unsafe fn put_current_reserved<'a, F>(
+    pub unsafe fn put_current_reserved_with_flags<'a, F>(
         &mut self,
+        flags: PutFlags,
         key: &'a KC::EItem,
         data_size: usize,
         write_func: F,
@@ -641,7 +643,7 @@ impl<'txn, KC, DC, IM> RwRevIter<'txn, KC, DC, IM> {
         F: FnMut(&mut ReservedSpace) -> io::Result<()>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
-        self.cursor.put_current_reserved(&key_bytes, data_size, write_func)
+        self.cursor.put_current_reserved_with_flags(flags, &key_bytes, data_size, write_func)
     }
 
     /// Insert a key-value pair in this database. The entry is written with the specified flags and data codec.

--- a/heed/src/iterator/iter.rs
+++ b/heed/src/iterator/iter.rs
@@ -331,6 +331,20 @@ impl<'txn, KC, DC, IM> RwIter<'txn, KC, DC, IM> {
         self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
     }
 
+    pub unsafe fn put_current_with_data_codec<'a, NDC>(
+        &mut self,
+        key: &'a KC::EItem,
+        data: &'a NDC::EItem,
+    ) -> Result<bool>
+    where
+        KC: BytesEncode<'a>,
+        NDC: BytesEncode<'a>,
+    {
+        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
+        let data_bytes: Cow<[u8]> = NDC::bytes_encode(data).map_err(Error::Encoding)?;
+        self.cursor.put_current(&key_bytes, &data_bytes)
+    }
+
     /// Move on the first value of keys, ignoring duplicate values.
     ///
     /// For more info, see [`RoIter::move_between_keys`].
@@ -674,6 +688,20 @@ impl<'txn, KC, DC, IM> RwRevIter<'txn, KC, DC, IM> {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(data).map_err(Error::Encoding)?;
         self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
+    }
+
+    pub unsafe fn put_current_with_data_codec<'a, NDC>(
+        &mut self,
+        key: &'a KC::EItem,
+        data: &'a NDC::EItem,
+    ) -> Result<bool>
+    where
+        KC: BytesEncode<'a>,
+        NDC: BytesEncode<'a>,
+    {
+        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
+        let data_bytes: Cow<[u8]> = NDC::bytes_encode(data).map_err(Error::Encoding)?;
+        self.cursor.put_current(&key_bytes, &data_bytes)
     }
 
     /// Move on the first value of keys, ignoring duplicate values.

--- a/heed/src/iterator/prefix.rs
+++ b/heed/src/iterator/prefix.rs
@@ -294,7 +294,7 @@ impl<'txn, KC, DC, C, IM> RwPrefix<'txn, KC, DC, C, IM> {
         self.cursor.put_current_reserved(&key_bytes, data_size, write_func)
     }
 
-    /// Insert a key-value pair in this database. The entry is written with the specified flags.
+    /// Insert a key-value pair in this database. The entry is written with the specified flags and data codec.
     ///
     /// For more info, see [`RwIter::put_current_with_flags`].
     ///
@@ -311,33 +311,19 @@ impl<'txn, KC, DC, C, IM> RwPrefix<'txn, KC, DC, C, IM> {
     /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-    pub unsafe fn put_current_with_flags<'a>(
+    pub unsafe fn put_current_with_options<'a, NDC>(
         &mut self,
         flags: PutFlags,
         key: &'a KC::EItem,
-        data: &'a DC::EItem,
-    ) -> Result<()>
-    where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
-    {
-        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
-        let data_bytes: Cow<[u8]> = DC::bytes_encode(data).map_err(Error::Encoding)?;
-        self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
-    }
-
-    pub unsafe fn put_current_with_data_codec<'a, NDC>(
-        &mut self,
-        key: &'a KC::EItem,
         data: &'a NDC::EItem,
-    ) -> Result<bool>
+    ) -> Result<()>
     where
         KC: BytesEncode<'a>,
         NDC: BytesEncode<'a>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = NDC::bytes_encode(data).map_err(Error::Encoding)?;
-        self.cursor.put_current(&key_bytes, &data_bytes)
+        self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
     }
 
     /// Move on the first value of keys, ignoring duplicate values.
@@ -694,7 +680,7 @@ impl<'txn, KC, DC, C, IM> RwRevPrefix<'txn, KC, DC, C, IM> {
         self.cursor.put_current_reserved(&key_bytes, data_size, write_func)
     }
 
-    /// Insert a key-value pair in this database. The entry is written with the specified flags.
+    /// Insert a key-value pair in this database. The entry is written with the specified flags and data codec.
     ///
     /// For more info, see [`RwIter::put_current_with_flags`].
     ///
@@ -711,33 +697,19 @@ impl<'txn, KC, DC, C, IM> RwRevPrefix<'txn, KC, DC, C, IM> {
     /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-    pub unsafe fn put_current_with_flags<'a>(
+    pub unsafe fn put_current_with_options<'a, NDC>(
         &mut self,
         flags: PutFlags,
         key: &'a KC::EItem,
-        data: &'a DC::EItem,
-    ) -> Result<()>
-    where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
-    {
-        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
-        let data_bytes: Cow<[u8]> = DC::bytes_encode(data).map_err(Error::Encoding)?;
-        self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
-    }
-
-    pub unsafe fn put_current_with_data_codec<'a, NDC>(
-        &mut self,
-        key: &'a KC::EItem,
         data: &'a NDC::EItem,
-    ) -> Result<bool>
+    ) -> Result<()>
     where
         KC: BytesEncode<'a>,
         NDC: BytesEncode<'a>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = NDC::bytes_encode(data).map_err(Error::Encoding)?;
-        self.cursor.put_current(&key_bytes, &data_bytes)
+        self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
     }
 
     /// Move on the first value of keys, ignoring duplicate values.

--- a/heed/src/iterator/prefix.rs
+++ b/heed/src/iterator/prefix.rs
@@ -326,6 +326,20 @@ impl<'txn, KC, DC, C, IM> RwPrefix<'txn, KC, DC, C, IM> {
         self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
     }
 
+    pub unsafe fn put_current_with_data_codec<'a, NDC>(
+        &mut self,
+        key: &'a KC::EItem,
+        data: &'a NDC::EItem,
+    ) -> Result<bool>
+    where
+        KC: BytesEncode<'a>,
+        NDC: BytesEncode<'a>,
+    {
+        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
+        let data_bytes: Cow<[u8]> = NDC::bytes_encode(data).map_err(Error::Encoding)?;
+        self.cursor.put_current(&key_bytes, &data_bytes)
+    }
+
     /// Move on the first value of keys, ignoring duplicate values.
     ///
     /// For more info, see [`RoIter::move_between_keys`].
@@ -710,6 +724,20 @@ impl<'txn, KC, DC, C, IM> RwRevPrefix<'txn, KC, DC, C, IM> {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(data).map_err(Error::Encoding)?;
         self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
+    }
+
+    pub unsafe fn put_current_with_data_codec<'a, NDC>(
+        &mut self,
+        key: &'a KC::EItem,
+        data: &'a NDC::EItem,
+    ) -> Result<bool>
+    where
+        KC: BytesEncode<'a>,
+        NDC: BytesEncode<'a>,
+    {
+        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
+        let data_bytes: Cow<[u8]> = NDC::bytes_encode(data).map_err(Error::Encoding)?;
+        self.cursor.put_current(&key_bytes, &data_bytes)
     }
 
     /// Move on the first value of keys, ignoring duplicate values.

--- a/heed/src/iterator/prefix.rs
+++ b/heed/src/iterator/prefix.rs
@@ -267,7 +267,7 @@ impl<'txn, KC, DC, C, IM> RwPrefix<'txn, KC, DC, C, IM> {
         self.cursor.put_current(&key_bytes, &data_bytes)
     }
 
-    /// Write a new value to the current entry.
+    /// Write a new value to the current entry. The entry is written with the specified flags.
     ///
     /// The given key **must** be equal to the one this cursor is pointing otherwise the database
     /// can be put into an inconsistent state.
@@ -280,8 +280,9 @@ impl<'txn, KC, DC, C, IM> RwPrefix<'txn, KC, DC, C, IM> {
     /// # Safety
     ///
     /// Please read the safety notes of the [`RwPrefix::put_current`] method.
-    pub unsafe fn put_current_reserved<'a, F>(
+    pub unsafe fn put_current_reserved_with_flags<'a, F>(
         &mut self,
+        flags: PutFlags,
         key: &'a KC::EItem,
         data_size: usize,
         write_func: F,
@@ -291,7 +292,7 @@ impl<'txn, KC, DC, C, IM> RwPrefix<'txn, KC, DC, C, IM> {
         F: FnMut(&mut ReservedSpace) -> io::Result<()>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
-        self.cursor.put_current_reserved(&key_bytes, data_size, write_func)
+        self.cursor.put_current_reserved_with_flags(flags, &key_bytes, data_size, write_func)
     }
 
     /// Insert a key-value pair in this database. The entry is written with the specified flags and data codec.
@@ -653,7 +654,7 @@ impl<'txn, KC, DC, C, IM> RwRevPrefix<'txn, KC, DC, C, IM> {
         self.cursor.put_current(&key_bytes, &data_bytes)
     }
 
-    /// Write a new value to the current entry.
+    /// Write a new value to the current entry. The entry is written with the specified flags.
     ///
     /// The given key **must** be equal to the one this cursor is pointing otherwise the database
     /// can be put into an inconsistent state.
@@ -666,8 +667,9 @@ impl<'txn, KC, DC, C, IM> RwRevPrefix<'txn, KC, DC, C, IM> {
     /// # Safety
     ///
     /// Please read the safety notes of the [`RwRevPrefix::put_current`] method.
-    pub unsafe fn put_current_reserved<'a, F>(
+    pub unsafe fn put_current_reserved_with_flags<'a, F>(
         &mut self,
+        flags: PutFlags,
         key: &'a KC::EItem,
         data_size: usize,
         write_func: F,
@@ -677,7 +679,7 @@ impl<'txn, KC, DC, C, IM> RwRevPrefix<'txn, KC, DC, C, IM> {
         F: FnMut(&mut ReservedSpace) -> io::Result<()>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
-        self.cursor.put_current_reserved(&key_bytes, data_size, write_func)
+        self.cursor.put_current_reserved_with_flags(flags, &key_bytes, data_size, write_func)
     }
 
     /// Insert a key-value pair in this database. The entry is written with the specified flags and data codec.

--- a/heed/src/iterator/range.rs
+++ b/heed/src/iterator/range.rs
@@ -303,7 +303,7 @@ impl<'txn, KC, DC, IM> RwRange<'txn, KC, DC, IM> {
         self.cursor.put_current_reserved(&key_bytes, data_size, write_func)
     }
 
-    /// Insert a key-value pair in this database. The entry is written with the specified flags.
+    /// Insert a key-value pair in this database. The entry is written with the specified flags and data codec.
     ///
     /// For more info, see [`RwIter::put_current_with_flags`].
     ///
@@ -320,33 +320,19 @@ impl<'txn, KC, DC, IM> RwRange<'txn, KC, DC, IM> {
     /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-    pub unsafe fn put_current_with_flags<'a>(
+    pub unsafe fn put_current_with_options<'a, NDC>(
         &mut self,
         flags: PutFlags,
         key: &'a KC::EItem,
-        data: &'a DC::EItem,
-    ) -> Result<()>
-    where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
-    {
-        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
-        let data_bytes: Cow<[u8]> = DC::bytes_encode(data).map_err(Error::Encoding)?;
-        self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
-    }
-
-    pub unsafe fn put_current_with_data_codec<'a, NDC>(
-        &mut self,
-        key: &'a KC::EItem,
         data: &'a NDC::EItem,
-    ) -> Result<bool>
+    ) -> Result<()>
     where
         KC: BytesEncode<'a>,
         NDC: BytesEncode<'a>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = NDC::bytes_encode(data).map_err(Error::Encoding)?;
-        self.cursor.put_current(&key_bytes, &data_bytes)
+        self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
     }
 
     /// Move on the first value of keys, ignoring duplicate values.
@@ -750,7 +736,7 @@ impl<'txn, KC, DC, IM> RwRevRange<'txn, KC, DC, IM> {
         self.cursor.put_current_reserved(&key_bytes, data_size, write_func)
     }
 
-    /// Insert a key-value pair in this database. The entry is written with the specified flags.
+    /// Insert a key-value pair in this database. The entry is written with the specified flags and data codec.
     ///
     /// For more info, see [`RwIter::put_current_with_flags`].
     ///
@@ -767,33 +753,19 @@ impl<'txn, KC, DC, IM> RwRevRange<'txn, KC, DC, IM> {
     /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-    pub unsafe fn put_current_with_flags<'a>(
+    pub unsafe fn put_current_with_options<'a, NDC>(
         &mut self,
         flags: PutFlags,
         key: &'a KC::EItem,
-        data: &'a DC::EItem,
-    ) -> Result<()>
-    where
-        KC: BytesEncode<'a>,
-        DC: BytesEncode<'a>,
-    {
-        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
-        let data_bytes: Cow<[u8]> = DC::bytes_encode(data).map_err(Error::Encoding)?;
-        self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
-    }
-
-    pub unsafe fn put_current_with_data_codec<'a, NDC>(
-        &mut self,
-        key: &'a KC::EItem,
         data: &'a NDC::EItem,
-    ) -> Result<bool>
+    ) -> Result<()>
     where
         KC: BytesEncode<'a>,
         NDC: BytesEncode<'a>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = NDC::bytes_encode(data).map_err(Error::Encoding)?;
-        self.cursor.put_current(&key_bytes, &data_bytes)
+        self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
     }
 
     /// Move on the first value of keys, ignoring duplicate values.

--- a/heed/src/iterator/range.rs
+++ b/heed/src/iterator/range.rs
@@ -276,7 +276,7 @@ impl<'txn, KC, DC, IM> RwRange<'txn, KC, DC, IM> {
         self.cursor.put_current(&key_bytes, &data_bytes)
     }
 
-    /// Write a new value to the current entry.
+    /// Write a new value to the current entry. The entry is written with the specified flags.
     ///
     /// The given key **must** be equal to the one this cursor is pointing otherwise the database
     /// can be put into an inconsistent state.
@@ -289,8 +289,9 @@ impl<'txn, KC, DC, IM> RwRange<'txn, KC, DC, IM> {
     /// # Safety
     ///
     /// Please read the safety notes of the [`RwRange::put_current`] method.
-    pub unsafe fn put_current_reserved<'a, F>(
+    pub unsafe fn put_current_reserved_with_flags<'a, F>(
         &mut self,
+        flags: PutFlags,
         key: &'a KC::EItem,
         data_size: usize,
         write_func: F,
@@ -300,7 +301,7 @@ impl<'txn, KC, DC, IM> RwRange<'txn, KC, DC, IM> {
         F: FnMut(&mut ReservedSpace) -> io::Result<()>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
-        self.cursor.put_current_reserved(&key_bytes, data_size, write_func)
+        self.cursor.put_current_reserved_with_flags(flags, &key_bytes, data_size, write_func)
     }
 
     /// Insert a key-value pair in this database. The entry is written with the specified flags and data codec.
@@ -709,7 +710,7 @@ impl<'txn, KC, DC, IM> RwRevRange<'txn, KC, DC, IM> {
         self.cursor.put_current(&key_bytes, &data_bytes)
     }
 
-    /// Write a new value to the current entry.
+    /// Write a new value to the current entry. The entry is written with the specified flags.
     ///
     /// The given key **must** be equal to the one this cursor is pointing otherwise the database
     /// can be put into an inconsistent state.
@@ -722,8 +723,9 @@ impl<'txn, KC, DC, IM> RwRevRange<'txn, KC, DC, IM> {
     /// # Safety
     ///
     /// Please read the safety notes of the [`RwRevRange::put_current`] method.
-    pub unsafe fn put_current_reserved<'a, F>(
+    pub unsafe fn put_current_reserved_with_flags<'a, F>(
         &mut self,
+        flags: PutFlags,
         key: &'a KC::EItem,
         data_size: usize,
         write_func: F,
@@ -733,7 +735,7 @@ impl<'txn, KC, DC, IM> RwRevRange<'txn, KC, DC, IM> {
         F: FnMut(&mut ReservedSpace) -> io::Result<()>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
-        self.cursor.put_current_reserved(&key_bytes, data_size, write_func)
+        self.cursor.put_current_reserved_with_flags(flags, &key_bytes, data_size, write_func)
     }
 
     /// Insert a key-value pair in this database. The entry is written with the specified flags and data codec.

--- a/heed/src/iterator/range.rs
+++ b/heed/src/iterator/range.rs
@@ -335,6 +335,20 @@ impl<'txn, KC, DC, IM> RwRange<'txn, KC, DC, IM> {
         self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
     }
 
+    pub unsafe fn put_current_with_data_codec<'a, NDC>(
+        &mut self,
+        key: &'a KC::EItem,
+        data: &'a NDC::EItem,
+    ) -> Result<bool>
+    where
+        KC: BytesEncode<'a>,
+        NDC: BytesEncode<'a>,
+    {
+        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
+        let data_bytes: Cow<[u8]> = NDC::bytes_encode(data).map_err(Error::Encoding)?;
+        self.cursor.put_current(&key_bytes, &data_bytes)
+    }
+
     /// Move on the first value of keys, ignoring duplicate values.
     ///
     /// For more info, see [`RoIter::move_between_keys`].
@@ -766,6 +780,20 @@ impl<'txn, KC, DC, IM> RwRevRange<'txn, KC, DC, IM> {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         let data_bytes: Cow<[u8]> = DC::bytes_encode(data).map_err(Error::Encoding)?;
         self.cursor.put_current_with_flags(flags, &key_bytes, &data_bytes)
+    }
+
+    pub unsafe fn put_current_with_data_codec<'a, NDC>(
+        &mut self,
+        key: &'a KC::EItem,
+        data: &'a NDC::EItem,
+    ) -> Result<bool>
+    where
+        KC: BytesEncode<'a>,
+        NDC: BytesEncode<'a>,
+    {
+        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
+        let data_bytes: Cow<[u8]> = NDC::bytes_encode(data).map_err(Error::Encoding)?;
+        self.cursor.put_current(&key_bytes, &data_bytes)
     }
 
     /// Move on the first value of keys, ignoring duplicate values.

--- a/heed/src/mdb/lmdb_flags.rs
+++ b/heed/src/mdb/lmdb_flags.rs
@@ -387,7 +387,8 @@ bitflags! {
         const NO_DUP_DATA = ffi::MDB_NODUPDATA;
         /// Enter the new key/data pair only if the key does not already appear in the database.
         ///
-        /// The function will return MDB_KEYEXIST if the key already appears in the database, even if the database supports duplicates (MDB_DUPSORT).
+        /// The function will return MDB_KEYEXIST if the key already appears in the database,
+        /// even if the database supports duplicates (MDB_DUPSORT).
         /// The data parameter will be set to point to the existing item.
         const NO_OVERWRITE = ffi::MDB_NOOVERWRITE;
         /// Append the given key/data pair to the end of the database.


### PR DESCRIPTION
In this PR, we rename the `Rw*Iter::put_current_with_flags` functions into `Rw*Iter::put_current_with_options` and make it possible to change the data codec simultaneously. This way, we do not introduce a new `put_current` function that cannot accept LMDB `PutFlags`.

We also modify the `Rw*Iter::put_current_reserved` into a `Rw*Iter::put_current_reserved_with_flags` to make it possible to specify other flags at the same time as using the "reserved" API interface.