### PR TITLE
Make the iterators `Send` when `read-txn-no-tls` is enabled

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -35,11 +35,11 @@ url = "2.3.1"
 default = ["serde", "serde-bincode", "serde-json"]
 serde = ["bitflags/serde", "dep:serde"]
 
-# The #MDB_NOTLS flag is automatically set on Env opening and
-# RoTxn implements the Send trait. This allows the user to move
-# a RoTxn between threads as read transactions will no more use
-# thread local storage and will tie reader locktable slots to
-# #MDB_txn objects instead of to threads.
+# The #MDB_NOTLS flag is automatically set on Env opening,
+# RoTxn and RoCursors implements the Send trait. This allows the
+# user to move RoTxns and RoCursors between threads as read transactions
+# will no more use thread local storage and will tie reader locktable
+# slots to #MDB_txn objects instead of to threads.
 #
 # According to the LMDB documentation, when this feature is not enabled:
 # A thread can only use one transaction at a time, plus any child

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -367,6 +367,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
 
     /// Returns an iterator over all of the values of a single key.
     ///
+    /// You can make this iterator `Send`able between threads by
+    /// using the `read-txn-no-tls` crate feature.
+    ///
     /// ```
     /// # use std::fs;
     /// # use std::path::Path;
@@ -960,6 +963,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
 
     /// Return a lexicographically ordered iterator of all key-value pairs in this database.
     ///
+    /// You can make this iterator `Send`able between threads by
+    /// using the `read-txn-no-tls` crate feature.
+    ///
     /// ```
     /// # use std::fs;
     /// # use std::path::Path;
@@ -1055,6 +1061,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     }
 
     /// Return a reversed lexicographically ordered iterator of all key-value pairs in this database.
+    ///
+    /// You can make this iterator `Send`able between threads by
+    /// using the `read-txn-no-tls` crate feature.
     ///
     /// ```
     /// # use std::fs;
@@ -1155,6 +1164,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// Return a lexicographically ordered iterator of a range of key-value pairs in this database.
     ///
     /// Comparisons are made by using the bytes representation of the key.
+    ///
+    /// You can make this iterator `Send`able between threads by
+    /// using the `read-txn-no-tls` crate feature.
     ///
     /// ```
     /// # use std::fs;
@@ -1325,6 +1337,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// Comparisons are made by using the bytes representation of the key.
     ///
+    /// You can make this iterator `Send`able between threads by
+    /// using the `read-txn-no-tls` crate feature.
+    ///
     /// ```
     /// # use std::fs;
     /// # use std::path::Path;
@@ -1494,6 +1509,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// Comparisons are made by using the bytes representation of the key.
     ///
+    /// You can make this iterator `Send`able between threads by
+    /// using the `read-txn-no-tls` crate feature.
+    ///
     /// ```
     /// # use std::fs;
     /// # use std::path::Path;
@@ -1620,6 +1638,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// in this database that starts with the given prefix.
     ///
     /// Comparisons are made by using the bytes representation of the key.
+    ///
+    /// You can make this iterator `Send`able between threads by
+    /// using the `read-txn-no-tls` crate feature.
     ///
     /// ```
     /// # use std::fs;

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -658,6 +658,9 @@ impl Env {
 
     /// Create a transaction with read-only access for use with the environment.
     ///
+    /// You can make this transaction `Send`able between threads by
+    /// using the `read-txn-no-tls` crate feature.
+    ///
     /// ## LMDB Limitations
     ///
     /// It's possible to have multiple read transactions in the same environment

--- a/heed/src/iterator/iter.rs
+++ b/heed/src/iterator/iter.rs
@@ -206,6 +206,9 @@ impl<KC, DC, IM> fmt::Debug for RoIter<'_, KC, DC, IM> {
     }
 }
 
+#[cfg(feature = "read-txn-no-tls")]
+unsafe impl<KC, DC, IM> Send for RoIter<'_, KC, DC, IM> {}
+
 /// A read-write iterator structure.
 pub struct RwIter<'txn, KC, DC, IM = MoveThroughDuplicateValues> {
     cursor: RwCursor<'txn>,
@@ -551,6 +554,9 @@ impl<KC, DC, IM> fmt::Debug for RoRevIter<'_, KC, DC, IM> {
         f.debug_struct("RoRevIter").finish()
     }
 }
+
+#[cfg(feature = "read-txn-no-tls")]
+unsafe impl<KC, DC, IM> Send for RoRevIter<'_, KC, DC, IM> {}
 
 /// A reverse read-write iterator structure.
 pub struct RwRevIter<'txn, KC, DC, IM = MoveThroughDuplicateValues> {

--- a/heed/src/iterator/prefix.rs
+++ b/heed/src/iterator/prefix.rs
@@ -200,6 +200,9 @@ impl<KC, DC, C, IM> fmt::Debug for RoPrefix<'_, KC, DC, C, IM> {
     }
 }
 
+#[cfg(feature = "read-txn-no-tls")]
+unsafe impl<KC, DC, IM> Send for RoPrefix<'_, KC, DC, IM> {}
+
 /// A read-write prefix iterator structure.
 pub struct RwPrefix<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {
     cursor: RwCursor<'txn>,
@@ -586,6 +589,9 @@ impl<KC, DC, C, IM> fmt::Debug for RoRevPrefix<'_, KC, DC, C, IM> {
         f.debug_struct("RoRevPrefix").finish()
     }
 }
+
+#[cfg(feature = "read-txn-no-tls")]
+unsafe impl<KC, DC, IM> Send for RoRevPrefix<'_, KC, DC, IM> {}
 
 /// A reverse read-write prefix iterator structure.
 pub struct RwRevPrefix<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {

--- a/heed/src/iterator/range.rs
+++ b/heed/src/iterator/range.rs
@@ -198,6 +198,9 @@ impl<KC, DC, IM> fmt::Debug for RoRange<'_, KC, DC, IM> {
     }
 }
 
+#[cfg(feature = "read-txn-no-tls")]
+unsafe impl<KC, DC, IM> Send for RoRange<'_, KC, DC, IM> {}
+
 /// A read-write range iterator structure.
 pub struct RwRange<'txn, KC, DC, IM = MoveThroughDuplicateValues> {
     cursor: RwCursor<'txn>,
@@ -631,6 +634,9 @@ impl<KC, DC, IM> fmt::Debug for RoRevRange<'_, KC, DC, IM> {
         f.debug_struct("RoRevRange").finish()
     }
 }
+
+#[cfg(feature = "read-txn-no-tls")]
+unsafe impl<KC, DC, IM> Send for RoRevRange<'_, KC, DC, IM> {}
 
 /// A reverse read-write range iterator structure.
 pub struct RwRevRange<'txn, KC, DC, IM = MoveThroughDuplicateValues> {


### PR DESCRIPTION
This PR closes #213 by making sure the iterators implement `Send` when the `read-txn-no-tls` feature is enabled.