### PR TITLE
Remove internal database type checking

### DIFF
--- a/heed/examples/all-types.rs
+++ b/heed/examples/all-types.rs
@@ -76,15 +76,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut wtxn = env.write_txn()?;
     let _db: Database<Str, Unit> = env.create_database(&mut wtxn, Some("ignored-data"))?;
 
-    // and here we try to open it with other types
-    // asserting that it correctly returns an error
-    //
-    // NOTE that those types are not saved upon runs and
-    // therefore types cannot be checked upon different runs,
-    // the first database opening fix the types for this run.
-    let result = env.create_database::<Str, SerdeJson<i32>>(&mut wtxn, Some("ignored-data"));
-    assert!(result.is_err());
-
     // you can iterate over keys in order
     type BEI64 = I64<BE>;
 

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -1,4 +1,3 @@
-use std::any::TypeId;
 use std::borrow::Cow;
 use std::ops::{Bound, RangeBounds};
 use std::{any, fmt, marker, mem, ptr};
@@ -139,8 +138,7 @@ impl<'e, 'n, KC, DC, C> DatabaseOpenOptions<'e, 'n, KC, DC, C> {
     {
         assert_eq_env_txn!(self.env, rtxn);
 
-        let types = (TypeId::of::<KC>(), TypeId::of::<DC>(), TypeId::of::<C>());
-        match self.env.raw_init_database::<C>(rtxn.txn, self.name, types, self.flags) {
+        match self.env.raw_init_database::<C>(rtxn.txn, self.name, self.flags) {
             Ok(dbi) => Ok(Some(Database::new(self.env.env_mut_ptr() as _, dbi))),
             Err(Error::Mdb(e)) if e.not_found() => Ok(None),
             Err(e) => Err(e),
@@ -164,9 +162,8 @@ impl<'e, 'n, KC, DC, C> DatabaseOpenOptions<'e, 'n, KC, DC, C> {
     {
         assert_eq_env_txn!(self.env, wtxn);
 
-        let types = (TypeId::of::<KC>(), TypeId::of::<DC>(), TypeId::of::<C>());
         let flags = self.flags | AllDatabaseFlags::CREATE;
-        match self.env.raw_init_database::<C>(wtxn.txn.txn, self.name, types, flags) {
+        match self.env.raw_init_database::<C>(wtxn.txn.txn, self.name, flags) {
             Ok(dbi) => Ok(Database::new(self.env.env_mut_ptr() as _, dbi)),
             Err(e) => Err(e),
         }

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -144,8 +144,6 @@ pub enum Error {
     Encoding(BoxedError),
     /// Decoding error.
     Decoding(BoxedError),
-    /// Incoherent types when opening a database.
-    InvalidDatabaseTyping,
     /// Database closing in progress.
     DatabaseClosing,
     /// Attempt to open [`Env`] with different options.
@@ -164,9 +162,6 @@ impl fmt::Display for Error {
             Error::Mdb(error) => write!(f, "{}", error),
             Error::Encoding(error) => write!(f, "error while encoding: {}", error),
             Error::Decoding(error) => write!(f, "error while decoding: {}", error),
-            Error::InvalidDatabaseTyping => {
-                f.write_str("database was previously opened with different types")
-            }
             Error::DatabaseClosing => {
                 f.write_str("database is in a closing phase, you can't open it at the same time")
             }

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -2,7 +2,7 @@ use std::ptr;
 
 pub use ffi::{
     mdb_cursor_close, mdb_cursor_del, mdb_cursor_get, mdb_cursor_open, mdb_cursor_put,
-    mdb_dbi_close, mdb_dbi_open, mdb_del, mdb_drop, mdb_env_close, mdb_env_copyfd2, mdb_env_create,
+    mdb_dbi_open, mdb_del, mdb_drop, mdb_env_close, mdb_env_copyfd2, mdb_env_create,
     mdb_env_get_fd, mdb_env_get_flags, mdb_env_info, mdb_env_open, mdb_env_set_mapsize,
     mdb_env_set_maxdbs, mdb_env_set_maxreaders, mdb_env_stat, mdb_env_sync, mdb_filehandle_t,
     mdb_get, mdb_put, mdb_reader_check, mdb_set_compare, mdb_stat, mdb_txn_abort, mdb_txn_begin,


### PR DESCRIPTION
This PR removes the security around checking that a database is always opened with the same codecs. It removes a mutex and simplifies some parts of the code. Note that it wasn't even useful because it was impossible to ensure the codec was the same between two program runs. One could use a codec to serialize the entries, and another could read them with another codec.