### PR TITLE
Introduce the first Cookbook

### DIFF
--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -212,7 +212,7 @@
 //!
 //! # Change the Environment Size Dynamically
 //!
-//! As you may now, you must specify the maximum size of an LMDB environment when you open it.
+//! You must specify the maximum size of an LMDB environment when you open it.
 //! Environment do not dynamically increase there size for performance reasons and also to
 //! have more control on it.
 //!

--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -12,7 +12,7 @@
 //! LMDB automatically stores their names in the unnamed database, a database that doesn't
 //! need to be created in which you can write.
 //!
-//! However, once you create new databases, after defining the [`EnvOpenOptions::max_dbs`]
+//! Once you create new databases, after defining the [`EnvOpenOptions::max_dbs`]
 //! parameter, the names of those databases are automatically stored in the unnamed one.
 //!
 //! ```

--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -1,4 +1,10 @@
-//! A cookbook of examples on how to use heed.
+//! A cookbook of examples on how to use heed. Here is the list of the different topics you can learn about:
+//!
+//! - [Listing and Opening the Named Databases](#listing-and-opening-the-named-databases)
+//! - [Create Custom and Prefix Codecs](#create-custom-and-prefix-codecs)
+//! - [Change the Environment Size Dynamically](#change-the-environment-size-dynamically)
+//! - [Decode Values on Demand](#decode-values-on-demand)
+//! - [Advanced Multithreaded Access of Entries](#advanced-multithreaded-access-of-entries)
 //!
 //! # Listing and Opening the Named Databases
 //!

--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -163,7 +163,7 @@
 //! use heed::{Database, EnvOpenOptions};
 //!
 //! fn main() -> Result<(), Box<dyn Error>> {
-//!     let path = Path::new("target").join("heed.mdb");
+//!     let path = Path::new("target").join("small-space.mdb");
 //!
 //!     fs::create_dir_all(&path)?;
 //!

--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -1,0 +1,71 @@
+//! A cookbook of examples on how to use heed.
+//!
+//! # Implement a custom codec with `BytesEncode`/`BytesDecode`
+//!
+//! With heed you can store any kind of data and serialize it the way you want.
+//! To do so you'll need to create a codec by usin the [`BytesEncode`] and [`BytesDecode`] traits.
+//!
+//! ```
+//! use std::borrow::Cow;
+//! use heed::{BoxedError, BytesEncode, BytesDecode};
+//!
+//! pub enum MyCounter<'a> {
+//!   One,
+//!   Two,
+//!   WhatIsThat(&'a [u8]),
+//! }
+//!
+//! pub struct MyCounterCodec;
+//!
+//! impl<'a> BytesEncode<'a> for MyCounterCodec {
+//!     type EItem = MyCounter<'a>;
+//!
+//!     fn bytes_encode(my_counter: &Self::EItem) -> Result<Cow<[u8]>, BoxedError> {
+//!         let mut output = Vec::new();
+//!
+//!         match my_counter {
+//!             MyCounter::One => output.push(1),
+//!             MyCounter::Two => output.push(2),
+//!             MyCounter::WhatIsThat(bytes) => {
+//!                 output.push(u8::MAX);
+//!                 output.extend_from_slice(bytes);
+//!             },
+//!         }
+//!
+//!         Ok(Cow::Owned(output))
+//!     }
+//! }
+//!
+//! impl<'a> BytesDecode<'a> for MyCounterCodec {
+//!     type DItem = MyCounter<'a>;
+//!
+//!     fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
+//!         match bytes[0] {
+//!             1 => Ok(MyCounter::One),
+//!             2 => Ok(MyCounter::One),
+//!             u8::MAX => Ok(MyCounter::WhatIsThat(&bytes[1..])),
+//!             _ => Err("invalid input".into()),
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//!
+//!
+//!
+//!
+//!
+//!
+//!
+//!
+//!
+//!
+//!
+//!
+//!
+//!
+
+// To let cargo generate doc links
+#![allow(unused_imports)]
+
+use crate::{BytesDecode, BytesEncode};

--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -9,8 +9,8 @@
 //! # Listing and Opening the Named Databases
 //!
 //! Sometimes it is useful to list the databases available in an environment.
-//! LMDB stores them already in the unnamed database, a database that is always
-//! there in which you can write.
+//! LMDB automatically stores their names in the unnamed database, a database that doesn't
+//! need to be created in which you can write.
 //!
 //! However, once you create new databases, after defining the [`EnvOpenOptions::max_dbs`]
 //! parameter, the names of those databases are automatically stored in the unnamed one.

--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -200,7 +200,7 @@
 //! }
 //!
 //! fn fill_with_data(wtxn: &mut heed::RwTxn, db: Database<Str, Str>) -> heed::Result<()> {
-//!     for i in 0..100 {
+//!     for i in 0..1000 {
 //!         let key = i.to_string();
 //!         db.put(wtxn, &key, "I am a very long string")?;
 //!     }

--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -28,10 +28,12 @@
 //!
 //!     fs::create_dir_all(&env_path)?;
 //!
-//!     let env = EnvOpenOptions::new()
-//!         .map_size(10 * 1024 * 1024) // 10MB
-//!         .max_dbs(3) // Number of opened databases
-//!         .open(env_path)?;
+//!     let env = unsafe {
+//!         EnvOpenOptions::new()
+//!             .map_size(10 * 1024 * 1024) // 10MB
+//!             .max_dbs(3) // Number of opened databases
+//!             .open(env_path)?
+//!     };
 //!
 //!     let rtxn = env.read_txn()?;
 //!     let unnamed: Database<Str, DecodeIgnore> =
@@ -165,10 +167,12 @@
 //!
 //!     fs::create_dir_all(&path)?;
 //!
-//!     let env = EnvOpenOptions::new()
-//!         .map_size(10 * 1024 * 1024) // 10MB
-//!         .max_dbs(3000)
-//!         .open(path)?;
+//!     let env = unsafe {
+//!         EnvOpenOptions::new()
+//!             .map_size(10 * 1024 * 1024) // 10MB
+//!             .max_dbs(3000)
+//!             .open(path)?
+//!     };
 //!
 //!     let mut wtxn = env.write_txn()?;
 //!     let db: Database<LogKeyCodec, Str> = env.create_database(&mut wtxn, None)?;
@@ -228,9 +232,11 @@
 //!
 //!     fs::create_dir_all(&path)?;
 //!
-//!     let env = EnvOpenOptions::new()
-//!         .map_size(16384) // one page
-//!         .open(&path)?;
+//!     let env = unsafe {
+//!         EnvOpenOptions::new()
+//!             .map_size(16384) // one page
+//!             .open(&path)?
+//!     };
 //!
 //!     let mut wtxn = env.write_txn()?;
 //!     let db: Database<Str, Str> = env.create_database(&mut wtxn, None)?;
@@ -247,9 +253,11 @@
 //!     // when no transaction are running so closing the env is easier.
 //!     env.prepare_for_closing().wait();
 //!
-//!     let env = EnvOpenOptions::new()
-//!         .map_size(10 * 16384) // 10 pages
-//!         .open(&path)?;
+//!     let env = unsafe {
+//!         EnvOpenOptions::new()
+//!             .map_size(10 * 16384) // 10 pages
+//!             .open(&path)?
+//!     };
 //!
 //!     let mut wtxn = env.write_txn()?;
 //!     let db: Database<Str, Str> = env.create_database(&mut wtxn, None)?;
@@ -291,9 +299,11 @@
 //!
 //!     fs::create_dir_all(&path)?;
 //!
-//!     let env = EnvOpenOptions::new()
-//!         .map_size(1024 * 1024 * 100) // 100 MiB
-//!         .open(&path)?;
+//!     let env = unsafe {
+//!         EnvOpenOptions::new()
+//!             .map_size(1024 * 1024 * 100) // 100 MiB
+//!             .open(&path)?
+//!     };
 //!
 //!     let mut wtxn = env.write_txn()?;
 //!     let db: Database<Str, SerdeJson<StringMap>> = env.create_database(&mut wtxn, None)?;
@@ -369,9 +379,11 @@
 //!
 //!     fs::create_dir_all(&path)?;
 //!
-//!     let env = EnvOpenOptions::new()
-//!         .map_size(1024 * 1024 * 100) // 100 MiB
-//!         .open(&path)?;
+//!     let env = unsafe {
+//!         EnvOpenOptions::new()
+//!             .map_size(1024 * 1024 * 100) // 100 MiB
+//!             .open(&path)?
+//!     };
 //!
 //!     let mut wtxn = env.write_txn()?;
 //!     let db: Database<Str, Str> = env.create_database(&mut wtxn, None)?;

--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -352,8 +352,8 @@
 //!
 //! This limits some usecases that require a parallel access to the content of the databases
 //! to process stuff faster. This is the case of arroy, a multithreads fast approximate
-//! neighbors search library. I wrote [an article to explain the tricks I implemented to be able
-//! to read entries in parallel while writing in another file][arroy article].
+//! neighbors search library. I wrote [an article explaining how
+//! to read entries in parallel][arroy article].
 //!
 //! It is forbidden to write in an environement while reading in it. However, it is possible
 //! to keep pointers to the values of the entries returned by LMDB. Those pointers are valid

--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -36,6 +36,8 @@
 //!     };
 //!
 //!     let rtxn = env.read_txn()?;
+//!     // The database names are mixed with the user entries therefore we prefer
+//!     // ignoring the values and try to open the databases one by one using the keys.
 //!     let unnamed: Database<Str, DecodeIgnore> =
 //!         env.open_database(&rtxn, None)?.expect("the unnamed database always exists");
 //!

--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -316,7 +316,7 @@
 //!     for (i, result) in db.lazily_decode_data().iter(&wtxn)?.enumerate() {
 //!         let (_key, lazy_value) = result?;
 //!         if i == 43 {
-//!             // This is where the magix happen. We receive a Lazy type
+//!             // This is where the magic happens. We receive a Lazy type
 //!             // that wraps a slice of bytes. We can decode on purpose.
 //!             let value = lazy_value.decode()?;
 //!             assert_eq!(value.get("secret"), Some(&String::from("434343")));

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -7,7 +7,7 @@
 
 //! `heed` is a high-level wrapper of [LMDB].
 //!
-//! The [cookbook] will give you a variety of complete Rust programs to use heed.
+//! The [cookbook] will give you a variety of complete Rust programs to use with heed.
 //!
 //! ----
 //!

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -7,6 +7,10 @@
 
 //! `heed` is a high-level wrapper of [LMDB].
 //!
+//! The [cookbook] will give you a variety of complete Rust programs to use heed.
+//!
+//! ----
+//!
 //! This crate simply facilitates the use of LMDB by providing a mechanism to store and
 //! retrieve Rust types. It abstracts away some of the complexities of the raw LMDB usage
 //! while retaining its performance characteristics. The functionality is achieved with the help
@@ -58,6 +62,7 @@
 //! ```
 #![warn(missing_docs)]
 
+pub mod cookbook;
 mod cursor;
 mod database;
 mod env;


### PR DESCRIPTION
Fixes #196.

- [x] Listing the names of the databases.
- [x] Implement a custom codec with `BytesEncode/BytesDecode`
- [x] Do prefix search with a custom codec.
- [x] Dynamically increase the size of the database by closing and reopening it
- [x] Show how to lazily decode types using the `LazyDecode` + `Lazy` structs.
- [x] Show how to [share content between threads safely even by using `RwTxn`](https://blog.kerollmops.com/multithreading-and-memory-mapping-refining-ann-performance-with-arroy).
- [x] Add good comments and explanations to the examples
- [x] Add a link section to navigate better
