### PR TITLE
Add `Env::set_flags()` and `FlagSetMode`

### DIFF
--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -77,7 +77,7 @@ use self::cursor::{RoCursor, RwCursor};
 pub use self::database::{Database, DatabaseOpenOptions, DatabaseStat};
 pub use self::env::{
     env_closing_event, CompactionOption, DefaultComparator, Env, EnvClosingEvent, EnvInfo,
-    EnvOpenOptions,
+    EnvOpenOptions, FlagSetMode,
 };
 pub use self::iterator::{
     RoIter, RoPrefix, RoRange, RoRevIter, RoRevPrefix, RoRevRange, RwIter, RwPrefix, RwRange,

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -3,11 +3,11 @@ use std::ptr;
 pub use ffi::{
     mdb_cursor_close, mdb_cursor_del, mdb_cursor_get, mdb_cursor_open, mdb_cursor_put,
     mdb_dbi_open, mdb_del, mdb_drop, mdb_env_close, mdb_env_copyfd2, mdb_env_create,
-    mdb_env_get_fd, mdb_env_get_flags, mdb_env_info, mdb_env_open, mdb_env_set_mapsize,
-    mdb_env_set_maxdbs, mdb_env_set_maxreaders, mdb_env_stat, mdb_env_sync, mdb_filehandle_t,
-    mdb_get, mdb_put, mdb_reader_check, mdb_set_compare, mdb_stat, mdb_txn_abort, mdb_txn_begin,
-    mdb_txn_commit, mdb_version, MDB_cursor, MDB_dbi, MDB_env, MDB_stat, MDB_txn, MDB_val,
-    MDB_CP_COMPACT, MDB_CURRENT, MDB_RDONLY, MDB_RESERVE,
+    mdb_env_get_fd, mdb_env_get_flags, mdb_env_info, mdb_env_open, mdb_env_set_flags,
+    mdb_env_set_mapsize, mdb_env_set_maxdbs, mdb_env_set_maxreaders, mdb_env_stat, mdb_env_sync,
+    mdb_filehandle_t, mdb_get, mdb_put, mdb_reader_check, mdb_set_compare, mdb_stat, mdb_txn_abort,
+    mdb_txn_begin, mdb_txn_commit, mdb_version, MDB_cursor, MDB_dbi, MDB_env, MDB_stat, MDB_txn,
+    MDB_val, MDB_CP_COMPACT, MDB_CURRENT, MDB_RDONLY, MDB_RESERVE,
 };
 use lmdb_master_sys as ffi;
 


### PR DESCRIPTION
Implements https://github.com/meilisearch/heed/issues/202.

This PR:
1. Exposes `mdb_env_set_flags()` via FFI which gets used in...
2. `Env::set_flags()` which enables/disables flags depending on...
3. the `FlagSetMode` enum which is either `Enable` or `Disable` 