### PR TITLE
Set `EnvOpenOptions::open()` to `unsafe`

### DIFF
--- a/heed/examples/all-types.rs
+++ b/heed/examples/all-types.rs
@@ -12,10 +12,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     fs::create_dir_all(&path)?;
 
-    let env = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024) // 10MB
-        .max_dbs(3000)
-        .open(path)?;
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024) // 10MB
+            .max_dbs(3000)
+            .open(path)?
+    };
 
     // here the key will be an str and the data will be a slice of u8
     let mut wtxn = env.write_txn()?;

--- a/heed/examples/clear-database.rs
+++ b/heed/examples/clear-database.rs
@@ -13,10 +13,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let _ = fs::remove_dir_all(&env_path);
 
     fs::create_dir_all(&env_path)?;
-    let env = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024) // 10MB
-        .max_dbs(3)
-        .open(env_path)?;
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024) // 10MB
+            .max_dbs(3)
+            .open(env_path)?
+    };
 
     let mut wtxn = env.write_txn()?;
     let db: Database<Str, Str> = env.create_database(&mut wtxn, Some("first"))?;

--- a/heed/examples/cursor-append.rs
+++ b/heed/examples/cursor-append.rs
@@ -13,10 +13,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let _ = fs::remove_dir_all(&env_path);
 
     fs::create_dir_all(&env_path)?;
-    let env = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024) // 10MB
-        .max_dbs(3)
-        .open(env_path)?;
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024) // 10MB
+            .max_dbs(3)
+            .open(env_path)?
+    };
 
     let mut wtxn = env.write_txn()?;
     let first: Database<Str, Str> = env.create_database(&mut wtxn, Some("first"))?;

--- a/heed/examples/custom-comparator.rs
+++ b/heed/examples/custom-comparator.rs
@@ -26,10 +26,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let _ = fs::remove_dir_all(&env_path);
 
     fs::create_dir_all(&env_path)?;
-    let env = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024) // 10MB
-        .max_dbs(3)
-        .open(env_path)?;
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024) // 10MB
+            .max_dbs(3)
+            .open(env_path)?
+    };
 
     let mut wtxn = env.write_txn()?;
     let db = env

--- a/heed/examples/multi-env.rs
+++ b/heed/examples/multi-env.rs
@@ -13,16 +13,20 @@ fn main() -> Result<(), Box<dyn Error>> {
     let env2_path = Path::new("target").join("env2.mdb");
 
     fs::create_dir_all(&env1_path)?;
-    let env1 = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024) // 10MB
-        .max_dbs(3000)
-        .open(env1_path)?;
+    let env1 = unsafe {
+        EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024) // 10MB
+            .max_dbs(3000)
+            .open(env1_path)?
+    };
 
     fs::create_dir_all(&env2_path)?;
-    let env2 = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024) // 10MB
-        .max_dbs(3000)
-        .open(env2_path)?;
+    let env2 = unsafe {
+        EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024) // 10MB
+            .max_dbs(3000)
+            .open(env2_path)?
+    };
 
     let mut wtxn1 = env1.write_txn()?;
     let mut wtxn2 = env2.write_txn()?;

--- a/heed/examples/nested.rs
+++ b/heed/examples/nested.rs
@@ -10,10 +10,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     fs::create_dir_all(&path)?;
 
-    let env = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024) // 10MB
-        .max_dbs(3000)
-        .open(path)?;
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024) // 10MB
+            .max_dbs(3000)
+            .open(path)?
+    };
 
     // here the key will be an str and the data will be a slice of u8
     let mut wtxn = env.write_txn()?;

--- a/heed/examples/rmp-serde.rs
+++ b/heed/examples/rmp-serde.rs
@@ -11,10 +11,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     fs::create_dir_all(&path)?;
 
-    let env = EnvOpenOptions::new()
-        .map_size(10 * 1024 * 1024) // 10MB
-        .max_dbs(3000)
-        .open(path)?;
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024) // 10MB
+            .max_dbs(3000)
+            .open(path)?
+    };
 
     // you can specify that a database will support some typed key/data
     // serde types are also supported!!!

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -28,10 +28,11 @@ use crate::*;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let dir = tempfile::tempdir()?;
-/// # let env = EnvOpenOptions::new()
+/// # let env = unsafe { EnvOpenOptions::new()
 /// #     .map_size(10 * 1024 * 1024) // 10MB
 /// #     .max_dbs(3000)
-/// #     .open(dir.path())?;
+/// #     .open(dir.path())?
+/// # };
 /// type BEI64 = I64<BigEndian>;
 ///
 /// // Imagine you have an optional name
@@ -196,10 +197,11 @@ impl<KC, DC, C> Copy for DatabaseOpenOptions<'_, '_, KC, DC, C> {}
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let dir = tempfile::tempdir()?;
-/// # let env = EnvOpenOptions::new()
+/// # let env = unsafe { EnvOpenOptions::new()
 /// #     .map_size(10 * 1024 * 1024) // 10MB
 /// #     .max_dbs(3000)
-/// #     .open(dir.path())?;
+/// #     .open(dir.path())?
+/// # };
 /// type BEI64 = I64<BigEndian>;
 ///
 /// let mut wtxn = env.write_txn()?;
@@ -243,10 +245,11 @@ impl<KC, DC, C> Copy for DatabaseOpenOptions<'_, '_, KC, DC, C> {}
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let dir = tempfile::tempdir()?;
-/// # let env = EnvOpenOptions::new()
+/// # let env = unsafe { EnvOpenOptions::new()
 /// #     .map_size(10 * 1024 * 1024) // 10MB
 /// #     .max_dbs(3000)
-/// #     .open(dir.path())?;
+/// #     .open(dir.path())?
+/// # };
 /// type BEI64 = I64<BigEndian>;
 ///
 /// let mut wtxn = env.write_txn()?;
@@ -313,10 +316,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32= U32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -376,10 +380,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI64 = I64<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -449,10 +454,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEU32 = U32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -517,10 +523,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEU32 = U32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -589,10 +596,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEU32 = U32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -660,10 +668,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEU32 = U32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -725,10 +734,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -778,10 +788,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -827,10 +838,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -869,10 +881,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -911,10 +924,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -973,10 +987,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1014,10 +1029,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1072,10 +1088,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1115,10 +1132,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1175,10 +1193,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1253,10 +1272,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1347,10 +1367,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1425,10 +1446,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1519,10 +1541,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1576,10 +1599,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1649,10 +1673,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1706,10 +1731,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1773,10 +1799,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1828,10 +1855,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1892,10 +1920,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -1979,10 +2008,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -2040,10 +2070,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI64 = I64<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -2130,10 +2161,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -2197,10 +2229,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -2246,10 +2279,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI32 = I32<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -500,7 +500,7 @@ impl Env {
     ///
     /// LMDB also requires that only 1 thread calls this function at any given moment.
     /// Neither `heed` or LMDB check for this condition, so the caller must ensure it explicitly.
-    pub unsafe fn set_flags(&mut self, flags: EnvFlags, mode: FlagSetMode) -> Result<()> {
+    pub unsafe fn set_flags(&self, flags: EnvFlags, mode: FlagSetMode) -> Result<()> {
         // safety: caller must ensure no other thread is calling this function.
         // <http://www.lmdb.tech/doc/group__mdb.html#ga83f66cf02bfd42119451e9468dc58445>
         mdb_result(unsafe {

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -205,30 +205,30 @@ impl EnvOpenOptions {
     ///
     /// These are some things to take note of:
     ///
-    /// - Do not call [`EnvOpenOptions::open`] twice in the same process, at the same time [^2]
-    /// - Avoid long-lived transactions, they will cause the database to grow quickly [^3]
-    /// - Avoid aborting your process with an active transaction [^4]
-    /// - Do not use LMDB on remote filesystems, even between processes on the same host [^5]
-    /// - You must manage concurrent accesses yourself if using [`EnvFlags::NO_LOCK`] [^6]
+    /// - Avoid long-lived transactions, they will cause the database to grow quickly [^2]
+    /// - Avoid aborting your process with an active transaction [^3]
+    /// - Do not use LMDB on remote filesystems, even between processes on the same host [^4]
+    /// - You must manage concurrent accesses yourself if using [`EnvFlags::NO_LOCK`] [^5]
+    /// - Anything that causes LMDB's lock file to be broken will cause synchronization issues and may introduce UB [^6]
     ///
-    /// Anything that causes the lock file to be broken (whether listed here or not)
-    /// will cause synchronization issues and may introduce UB. [^7]
+    /// `heed` itself upholds some safety invariants, including but not limited to:
+    /// - Calling [`EnvOpenOptions::open`] twice in the same process, at the same time is OK [^7]
     ///
     /// For more details, it is highly recommended to read LMDB's official documentation. [^8]
     ///
     /// [^1]: <https://en.wikipedia.org/wiki/Memory_map>
     ///
-    /// [^2]: <https://github.com/LMDB/lmdb/blob/b8e54b4c31378932b69f1298972de54a565185b1/libraries/liblmdb/lmdb.h#L102-L105>
+    /// [^2]: <https://github.com/LMDB/lmdb/blob/b8e54b4c31378932b69f1298972de54a565185b1/libraries/liblmdb/lmdb.h#L107-L114>
     ///
-    /// [^3]: <https://github.com/LMDB/lmdb/blob/b8e54b4c31378932b69f1298972de54a565185b1/libraries/liblmdb/lmdb.h#L107-L114>
+    /// [^3]: <https://github.com/LMDB/lmdb/blob/b8e54b4c31378932b69f1298972de54a565185b1/libraries/liblmdb/lmdb.h#L118-L121>
     ///
-    /// [^4]: <https://github.com/LMDB/lmdb/blob/b8e54b4c31378932b69f1298972de54a565185b1/libraries/liblmdb/lmdb.h#L118-L121>
+    /// [^4]: <https://github.com/LMDB/lmdb/blob/b8e54b4c31378932b69f1298972de54a565185b1/libraries/liblmdb/lmdb.h#L129>
     ///
     /// [^5]: <https://github.com/LMDB/lmdb/blob/b8e54b4c31378932b69f1298972de54a565185b1/libraries/liblmdb/lmdb.h#L129>
     ///
-    /// [^6]: <https://github.com/LMDB/lmdb/blob/b8e54b4c31378932b69f1298972de54a565185b1/libraries/liblmdb/lmdb.h#L129>
+    /// [^6]: <https://github.com/LMDB/lmdb/blob/b8e54b4c31378932b69f1298972de54a565185b1/libraries/liblmdb/lmdb.h#L49-L52>
     ///
-    /// [^7]: <https://github.com/LMDB/lmdb/blob/b8e54b4c31378932b69f1298972de54a565185b1/libraries/liblmdb/lmdb.h#L49-L52>
+    /// [^7]: <https://github.com/LMDB/lmdb/blob/b8e54b4c31378932b69f1298972de54a565185b1/libraries/liblmdb/lmdb.h#L102-L105>
     ///
     /// [^8]: <http://www.lmdb.tech/doc/index.html>
     pub unsafe fn open<P: AsRef<Path>>(&self, path: P) -> Result<Env> {

--- a/heed/src/iterator/iter.rs
+++ b/heed/src/iterator/iter.rs
@@ -29,10 +29,11 @@ impl<'txn, KC, DC, IM> RoIter<'txn, KC, DC, IM> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI64 = I64<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;
@@ -81,10 +82,11 @@ impl<'txn, KC, DC, IM> RoIter<'txn, KC, DC, IM> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let dir = tempfile::tempdir()?;
-    /// # let env = EnvOpenOptions::new()
+    /// # let env = unsafe { EnvOpenOptions::new()
     /// #     .map_size(10 * 1024 * 1024) // 10MB
     /// #     .max_dbs(3000)
-    /// #     .open(dir.path())?;
+    /// #     .open(dir.path())?
+    /// # };
     /// type BEI64 = I64<BigEndian>;
     ///
     /// let mut wtxn = env.write_txn()?;

--- a/heed/src/iterator/mod.rs
+++ b/heed/src/iterator/mod.rs
@@ -16,11 +16,13 @@ mod tests {
         use crate::EnvOpenOptions;
 
         let dir = tempfile::tempdir().unwrap();
-        let env = EnvOpenOptions::new()
-            .map_size(10 * 1024 * 1024) // 10MB
-            .max_dbs(3000)
-            .open(dir.path())
-            .unwrap();
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .map_size(10 * 1024 * 1024) // 10MB
+                .max_dbs(3000)
+                .open(dir.path())
+                .unwrap()
+        };
 
         let mut wtxn = env.write_txn().unwrap();
         let db = env.create_database::<Bytes, Str>(&mut wtxn, None).unwrap();
@@ -96,11 +98,13 @@ mod tests {
         use crate::EnvOpenOptions;
 
         let dir = tempfile::tempdir().unwrap();
-        let env = EnvOpenOptions::new()
-            .map_size(10 * 1024 * 1024) // 10MB
-            .max_dbs(3000)
-            .open(dir.path())
-            .unwrap();
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .map_size(10 * 1024 * 1024) // 10MB
+                .max_dbs(3000)
+                .open(dir.path())
+                .unwrap()
+        };
 
         let mut wtxn = env.write_txn().unwrap();
         let db = env.create_database::<BEI32, Unit>(&mut wtxn, None).unwrap();
@@ -164,11 +168,13 @@ mod tests {
         use crate::EnvOpenOptions;
 
         let dir = tempfile::tempdir().unwrap();
-        let env = EnvOpenOptions::new()
-            .map_size(10 * 1024 * 1024) // 10MB
-            .max_dbs(3000)
-            .open(dir.path())
-            .unwrap();
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .map_size(10 * 1024 * 1024) // 10MB
+                .max_dbs(3000)
+                .open(dir.path())
+                .unwrap()
+        };
 
         let mut wtxn = env.write_txn().unwrap();
         let db = env.create_database::<BEI32, Unit>(&mut wtxn, None).unwrap();
@@ -256,11 +262,13 @@ mod tests {
         use crate::EnvOpenOptions;
 
         let dir = tempfile::tempdir().unwrap();
-        let env = EnvOpenOptions::new()
-            .map_size(10 * 1024 * 1024) // 10MB
-            .max_dbs(3000)
-            .open(dir.path())
-            .unwrap();
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .map_size(10 * 1024 * 1024) // 10MB
+                .max_dbs(3000)
+                .open(dir.path())
+                .unwrap()
+        };
 
         let mut wtxn = env.write_txn().unwrap();
         let db = env.create_database::<Bytes, Unit>(&mut wtxn, None).unwrap();
@@ -304,11 +312,13 @@ mod tests {
         use crate::EnvOpenOptions;
 
         let dir = tempfile::tempdir().unwrap();
-        let env = EnvOpenOptions::new()
-            .map_size(10 * 1024 * 1024) // 10MB
-            .max_dbs(3000)
-            .open(dir.path())
-            .unwrap();
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .map_size(10 * 1024 * 1024) // 10MB
+                .max_dbs(3000)
+                .open(dir.path())
+                .unwrap()
+        };
 
         let mut wtxn = env.write_txn().unwrap();
         let db = env.create_database::<Bytes, Unit>(&mut wtxn, None).unwrap();
@@ -379,11 +389,13 @@ mod tests {
         use crate::EnvOpenOptions;
 
         let dir = tempfile::tempdir().unwrap();
-        let env = EnvOpenOptions::new()
-            .map_size(10 * 1024 * 1024) // 10MB
-            .max_dbs(3000)
-            .open(dir.path())
-            .unwrap();
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .map_size(10 * 1024 * 1024) // 10MB
+                .max_dbs(3000)
+                .open(dir.path())
+                .unwrap()
+        };
 
         let mut wtxn = env.write_txn().unwrap();
         let db = env.create_database::<Bytes, Unit>(&mut wtxn, None).unwrap();
@@ -454,11 +466,13 @@ mod tests {
         use crate::EnvOpenOptions;
 
         let dir = tempfile::tempdir().unwrap();
-        let env = EnvOpenOptions::new()
-            .map_size(10 * 1024 * 1024) // 10MB
-            .max_dbs(3000)
-            .open(dir.path())
-            .unwrap();
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .map_size(10 * 1024 * 1024) // 10MB
+                .max_dbs(3000)
+                .open(dir.path())
+                .unwrap()
+        };
 
         let mut wtxn = env.write_txn().unwrap();
         let db = env.create_database::<Bytes, Unit>(&mut wtxn, None).unwrap();
@@ -524,11 +538,13 @@ mod tests {
         use crate::EnvOpenOptions;
 
         let dir = tempfile::tempdir().unwrap();
-        let env = EnvOpenOptions::new()
-            .map_size(10 * 1024 * 1024) // 10MB
-            .max_dbs(3000)
-            .open(dir.path())
-            .unwrap();
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .map_size(10 * 1024 * 1024) // 10MB
+                .max_dbs(3000)
+                .open(dir.path())
+                .unwrap()
+        };
 
         let mut wtxn = env.write_txn().unwrap();
         let db = env.create_database::<BEI32, Unit>(&mut wtxn, None).unwrap();
@@ -575,11 +591,13 @@ mod tests {
         use crate::EnvOpenOptions;
 
         let dir = tempfile::tempdir().unwrap();
-        let env = EnvOpenOptions::new()
-            .map_size(10 * 1024 * 1024) // 10MB
-            .max_dbs(3000)
-            .open(dir.path())
-            .unwrap();
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .map_size(10 * 1024 * 1024) // 10MB
+                .max_dbs(3000)
+                .open(dir.path())
+                .unwrap()
+        };
 
         let mut wtxn = env.write_txn().unwrap();
         let db = env.create_database::<Bytes, Unit>(&mut wtxn, None).unwrap();

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let dir = tempfile::tempdir()?;
-//! let env = EnvOpenOptions::new().open(dir.path())?;
+//! let env = unsafe { EnvOpenOptions::new().open(dir.path())? };
 //!
 //! // we will open the default unnamed database
 //! let mut wtxn = env.write_txn()?;

--- a/heed/src/mdb/lmdb_flags.rs
+++ b/heed/src/mdb/lmdb_flags.rs
@@ -73,10 +73,11 @@ bitflags! {
         ///
         /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
         /// # let dir = tempfile::tempdir()?;
-        /// # let env = EnvOpenOptions::new()
+        /// # let env = unsafe { EnvOpenOptions::new()
         /// #     .map_size(10 * 1024 * 1024) // 10MB
         /// #     .max_dbs(3000)
-        /// #     .open(dir.path())?;
+        /// #     .open(dir.path())?
+        /// # };
         ///
         /// let mut wtxn = env.write_txn()?;
         /// let db = env.database_options()
@@ -119,10 +120,11 @@ bitflags! {
         ///
         /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
         /// # let dir = tempfile::tempdir()?;
-        /// # let env = EnvOpenOptions::new()
+        /// # let env = unsafe { EnvOpenOptions::new()
         /// #     .map_size(10 * 1024 * 1024) // 10MB
         /// #     .max_dbs(3000)
-        /// #     .open(dir.path())?;
+        /// #     .open(dir.path())?
+        /// # };
         /// type BEI64 = I64<BigEndian>;
         ///
         /// let mut wtxn = env.write_txn()?;
@@ -179,10 +181,11 @@ bitflags! {
         ///
         /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
         /// # let dir = tempfile::tempdir()?;
-        /// # let env = EnvOpenOptions::new()
+        /// # let env = unsafe { EnvOpenOptions::new()
         /// #     .map_size(10 * 1024 * 1024) // 10MB
         /// #     .max_dbs(3000)
-        /// #     .open(dir.path())?;
+        /// #     .open(dir.path())?
+        /// # };
         /// type BEI32 = I32<BigEndian>;
         ///
         /// let mut wtxn = env.write_txn()?;
@@ -223,10 +226,11 @@ bitflags! {
         ///
         /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
         /// # let dir = tempfile::tempdir()?;
-        /// # let env = EnvOpenOptions::new()
+        /// # let env = unsafe { EnvOpenOptions::new()
         /// #     .map_size(10 * 1024 * 1024) // 10MB
         /// #     .max_dbs(3000)
-        /// #     .open(dir.path())?;
+        /// #     .open(dir.path())?
+        /// # };
         /// type BEI64 = I64<BigEndian>;
         ///
         /// let mut wtxn = env.write_txn()?;
@@ -282,10 +286,11 @@ bitflags! {
         ///
         /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
         /// # let dir = tempfile::tempdir()?;
-        /// # let env = EnvOpenOptions::new()
+        /// # let env = unsafe { EnvOpenOptions::new()
         /// #     .map_size(10 * 1024 * 1024) // 10MB
         /// #     .max_dbs(3000)
-        /// #     .open(dir.path())?;
+        /// #     .open(dir.path())?
+        /// # };
         /// type BEI32 = I32<BigEndian>;
         ///
         /// let mut wtxn = env.write_txn()?;
@@ -341,10 +346,11 @@ bitflags! {
         ///
         /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
         /// # let dir = tempfile::tempdir()?;
-        /// # let env = EnvOpenOptions::new()
+        /// # let env = unsafe { EnvOpenOptions::new()
         /// #     .map_size(10 * 1024 * 1024) // 10MB
         /// #     .max_dbs(3000)
-        /// #     .open(dir.path())?;
+        /// #     .open(dir.path())?
+        /// # };
         /// type BEI64 = I64<BigEndian>;
         ///
         /// let mut wtxn = env.write_txn()?;


### PR DESCRIPTION
Closes https://github.com/meilisearch/heed/issues/207.

- `fn EnvOpenOptions::open()` -> `unsafe fn EnvOpenOptions::open()`
- Adds `# Safety` documentation
- Fixes all callers to use `unsafe`

`heed` can actually uphold some of the safety invariants, but for now they are documented so at least users are aware of them.

Unrelated change: the new `Env::set_flags` (https://github.com/meilisearch/heed/pull/245) doesn't necessarily gain safety from `&mut self`, so it is changed to `&self`.