### PR TITLE
Bump lmdb-master-sys to 0.2.0

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = { version = "1.4.3", default-features = false }
 heed-traits = { version = "0.20.0", path = "../heed-traits" }
 heed-types = { version = "0.20.0", default-features = false, path = "../heed-types" }
 libc = "0.2.139"
-lmdb-master-sys = { version = "0.1.0", path = "../lmdb-master-sys" }
+lmdb-master-sys = { version = "0.2.0", path = "../lmdb-master-sys" }
 once_cell = "1.16.0"
 page_size = "0.6.0"
 serde = { version = "1.0.151", features = ["derive"], optional = true }

--- a/lmdb-master-sys/Cargo.toml
+++ b/lmdb-master-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lmdb-master-sys"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Kerollmops <clement@meilisearch.com>",
     "Dan Burkert <dan@danburkert.com>",

--- a/lmdb-master-sys/src/lib.rs
+++ b/lmdb-master-sys/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(rustdoc::invalid_html_tags)]
 #![allow(non_camel_case_types)]
 #![allow(clippy::all)]
-#![doc(html_root_url = "https://docs.rs/lmdb-master-sys/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/lmdb-master-sys/0.2.0")]
 
 extern crate libc;
 


### PR DESCRIPTION
This PR bumps lmdb-master-sys to 0.2.0 to expose the new `mdb_idl_logn` feature flags.