### PR TITLE
replace all `FnMut` with `FnOnce` in `put_reserve_*`

### DIFF
--- a/heed/src/cursor.rs
+++ b/heed/src/cursor.rs
@@ -334,10 +334,10 @@ impl<'txn> RwCursor<'txn> {
         flags: PutFlags,
         key: &[u8],
         data_size: usize,
-        mut write_func: F,
+        write_func: F,
     ) -> Result<bool>
     where
-        F: FnMut(&mut ReservedSpace) -> io::Result<()>,
+        F: FnOnce(&mut ReservedSpace) -> io::Result<()>,
     {
         let mut key_val = crate::into_val(key);
         let mut reserved = ffi::reserve_size_val(data_size);
@@ -353,7 +353,7 @@ impl<'txn> RwCursor<'txn> {
         };
 
         let mut reserved = ReservedSpace::from_val(reserved);
-        (write_func)(&mut reserved)?;
+        write_func(&mut reserved)?;
 
         if reserved.remaining() == 0 {
             Ok(found)

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -1882,11 +1882,11 @@ impl<KC, DC, C> Database<KC, DC, C> {
         txn: &mut RwTxn,
         key: &'a KC::EItem,
         data_size: usize,
-        mut write_func: F,
+        write_func: F,
     ) -> Result<()>
     where
         KC: BytesEncode<'a>,
-        F: FnMut(&mut ReservedSpace) -> io::Result<()>,
+        F: FnOnce(&mut ReservedSpace) -> io::Result<()>,
     {
         assert_eq_env_db_txn!(self, txn);
 
@@ -1900,7 +1900,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
         }
 
         let mut reserved = unsafe { ReservedSpace::from_val(reserved) };
-        (write_func)(&mut reserved)?;
+        write_func(&mut reserved)?;
         if reserved.remaining() == 0 {
             Ok(())
         } else {

--- a/heed/src/iterator/iter.rs
+++ b/heed/src/iterator/iter.rs
@@ -299,7 +299,7 @@ impl<'txn, KC, DC, IM> RwIter<'txn, KC, DC, IM> {
     ) -> Result<bool>
     where
         KC: BytesEncode<'a>,
-        F: FnMut(&mut ReservedSpace) -> io::Result<()>,
+        F: FnOnce(&mut ReservedSpace) -> io::Result<()>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         self.cursor.put_current_reserved_with_flags(flags, &key_bytes, data_size, write_func)
@@ -648,7 +648,7 @@ impl<'txn, KC, DC, IM> RwRevIter<'txn, KC, DC, IM> {
     ) -> Result<bool>
     where
         KC: BytesEncode<'a>,
-        F: FnMut(&mut ReservedSpace) -> io::Result<()>,
+        F: FnOnce(&mut ReservedSpace) -> io::Result<()>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         self.cursor.put_current_reserved_with_flags(flags, &key_bytes, data_size, write_func)

--- a/heed/src/iterator/prefix.rs
+++ b/heed/src/iterator/prefix.rs
@@ -292,7 +292,7 @@ impl<'txn, KC, DC, C, IM> RwPrefix<'txn, KC, DC, C, IM> {
     ) -> Result<bool>
     where
         KC: BytesEncode<'a>,
-        F: FnMut(&mut ReservedSpace) -> io::Result<()>,
+        F: FnOnce(&mut ReservedSpace) -> io::Result<()>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         self.cursor.put_current_reserved_with_flags(flags, &key_bytes, data_size, write_func)
@@ -682,7 +682,7 @@ impl<'txn, KC, DC, C, IM> RwRevPrefix<'txn, KC, DC, C, IM> {
     ) -> Result<bool>
     where
         KC: BytesEncode<'a>,
-        F: FnMut(&mut ReservedSpace) -> io::Result<()>,
+        F: FnOnce(&mut ReservedSpace) -> io::Result<()>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         self.cursor.put_current_reserved_with_flags(flags, &key_bytes, data_size, write_func)

--- a/heed/src/iterator/range.rs
+++ b/heed/src/iterator/range.rs
@@ -301,7 +301,7 @@ impl<'txn, KC, DC, IM> RwRange<'txn, KC, DC, IM> {
     ) -> Result<bool>
     where
         KC: BytesEncode<'a>,
-        F: FnMut(&mut ReservedSpace) -> io::Result<()>,
+        F: FnOnce(&mut ReservedSpace) -> io::Result<()>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         self.cursor.put_current_reserved_with_flags(flags, &key_bytes, data_size, write_func)
@@ -738,7 +738,7 @@ impl<'txn, KC, DC, IM> RwRevRange<'txn, KC, DC, IM> {
     ) -> Result<bool>
     where
         KC: BytesEncode<'a>,
-        F: FnMut(&mut ReservedSpace) -> io::Result<()>,
+        F: FnOnce(&mut ReservedSpace) -> io::Result<()>,
     {
         let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
         self.cursor.put_current_reserved_with_flags(flags, &key_bytes, data_size, write_func)


### PR DESCRIPTION
# Pull Request

## Related issue
N/A

## What does this PR do?
- Replaces `FnMut` with `FnOnce` in all `put_reserve_*` functions.
    - A value should only be written once, so `FnMut` is needlessly restrictive; with `FnOnce` we allow more functions to be used.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
