### PR TITLE
Add `Database::get_or_put`: insert if value does not exist, otherwise return previous value

### DIFF
--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -1997,7 +1997,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     }
 
     /// Attempt to insert a key-value pair in this database, or if a value already exists for the
-    /// key, returns the previous value. The entry is written with no specific flag.
+    /// key, returns the previous value.
+    ///
+    /// The entry is always written with the [`NO_OVERWRITE`](PutFlags::NO_OVERWRITE) flag.
     ///
     /// ```
     /// # use heed::EnvOpenOptions;
@@ -2041,7 +2043,10 @@ impl<KC, DC, C> Database<KC, DC, C> {
     }
 
     /// Attempt to insert a key-value pair in this database, or if a value already exists for the
-    /// key, returns the previous value. The entry is written with the specified flags.
+    /// key, returns the previous value.
+    ///
+    /// The entry is written with the specified flags, in addition to
+    /// [`NO_OVERWRITE`](PutFlags::NO_OVERWRITE) which is always used.
     ///
     /// ```
     /// # use heed::EnvOpenOptions;
@@ -2113,7 +2118,8 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// Attempt to insert a key-value pair in this database, where the value can be directly
     /// written to disk, or if a value already exists for the key, returns the previous value.
     ///
-    /// The entry is written with no specific flags.
+    /// The entry is always written with the [`NO_OVERWRITE`](PutFlags::NO_OVERWRITE) and
+    /// [`MDB_RESERVE`](lmdb_master_sys::MDB_RESERVE) flags.
     ///
     /// ```
     /// # use heed::EnvOpenOptions;
@@ -2175,7 +2181,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// Attempt to insert a key-value pair in this database, where the value can be directly
     /// written to disk, or if a value already exists for the key, returns the previous value.
     ///
-    /// The entry is written with the specified flags.
+    /// The entry is written with the specified flags, in addition to
+    /// [`NO_OVERWRITE`](PutFlags::NO_OVERWRITE) and [`MDB_RESERVE`](lmdb_master_sys::MDB_RESERVE)
+    /// which are always used.
     ///
     /// ```
     /// # use heed::EnvOpenOptions;

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -1993,6 +1993,116 @@ impl<KC, DC, C> Database<KC, DC, C> {
         Ok(())
     }
 
+    /// Attempt to insert a key-value pair in this database, or if a value already exists for the
+    /// key, returns the previous value. The entry is written with no specific flag.
+    ///
+    /// ```
+    /// # use heed::EnvOpenOptions;
+    /// use heed::Database;
+    /// use heed::types::*;
+    /// use heed::byteorder::BigEndian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let dir = tempfile::tempdir()?;
+    /// # let env = unsafe { EnvOpenOptions::new()
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
+    /// #     .max_dbs(3000)
+    /// #     .open(dir.path())?
+    /// # };
+    /// type BEI32 = I32<BigEndian>;
+    ///
+    /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<BEI32, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
+    /// # db.clear(&mut wtxn)?;
+    /// assert_eq!(db.get_or_put(&mut wtxn, &42, "i-am-forty-two")?, None);
+    /// assert_eq!(db.get_or_put(&mut wtxn, &42, "the meaning of life")?, Some("i-am-forty-two"));
+    ///
+    /// let ret = db.get(&mut wtxn, &42)?;
+    /// assert_eq!(ret, Some("i-am-forty-two"));
+    ///
+    /// wtxn.commit()?;
+    /// # Ok(()) }
+    /// ```
+    pub fn get_or_put<'a, 'txn>(
+        &'txn self,
+        txn: &mut RwTxn,
+        key: &'a KC::EItem,
+        data: &'a DC::EItem,
+    ) -> Result<Option<DC::DItem>>
+    where
+        KC: BytesEncode<'a>,
+        DC: BytesEncode<'a> + BytesDecode<'a>,
+    {
+        self.get_or_put_with_flags(txn, PutFlags::empty(), key, data)
+    }
+
+    /// Attempt to insert a key-value pair in this database, or if a value already exists for the
+    /// key, returns the previous value. The entry is written with the specified flags.
+    ///
+    /// ```
+    /// # use heed::EnvOpenOptions;
+    /// use heed::{Database, PutFlags};
+    /// use heed::types::*;
+    /// use heed::byteorder::BigEndian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let dir = tempfile::tempdir()?;
+    /// # let env = unsafe { EnvOpenOptions::new()
+    /// #     .map_size(10 * 1024 * 1024) // 10MB
+    /// #     .max_dbs(3000)
+    /// #     .open(dir.path())?
+    /// # };
+    /// type BEI32 = I32<BigEndian>;
+    ///
+    /// let mut wtxn = env.write_txn()?;
+    /// let db: Database<BEI32, Str> = env.create_database(&mut wtxn, Some("iter-i32"))?;
+    ///
+    /// # db.clear(&mut wtxn)?;
+    /// assert_eq!(db.get_or_put_with_flags(&mut wtxn, PutFlags::empty(), &42, "i-am-forty-two")?, None);
+    /// assert_eq!(db.get_or_put_with_flags(&mut wtxn, PutFlags::empty(), &42, "the meaning of life")?, Some("i-am-forty-two"));
+    ///
+    /// let ret = db.get(&mut wtxn, &42)?;
+    /// assert_eq!(ret, Some("i-am-forty-two"));
+    ///
+    /// wtxn.commit()?;
+    /// # Ok(()) }
+    /// ```
+    pub fn get_or_put_with_flags<'a, 'txn>(
+        &'txn self,
+        txn: &mut RwTxn,
+        flags: PutFlags,
+        key: &'a KC::EItem,
+        data: &'a DC::EItem,
+    ) -> Result<Option<DC::DItem>>
+    where
+        KC: BytesEncode<'a>,
+        DC: BytesEncode<'a> + BytesDecode<'a>,
+    {
+        assert_eq_env_db_txn!(self, txn);
+
+        let key_bytes: Cow<[u8]> = KC::bytes_encode(key).map_err(Error::Encoding)?;
+        let data_bytes: Cow<[u8]> = DC::bytes_encode(data).map_err(Error::Encoding)?;
+
+        let mut key_val = unsafe { crate::into_val(&key_bytes) };
+        let mut data_val = unsafe { crate::into_val(&data_bytes) };
+        let flags = (flags | PutFlags::NO_OVERWRITE).bits();
+
+        unsafe {
+            match ffi::mdb_put(txn.txn.txn, self.dbi, &mut key_val, &mut data_val, flags) {
+                lmdb_master_sys::MDB_KEYEXIST => {
+                    let bytes = crate::from_val(data_val);
+                    let data = DC::bytes_decode(bytes).map_err(Error::Decoding)?;
+                    Ok(Some(data))
+                }
+                err_code => {
+                    mdb_result(err_code)?;
+                    Ok(None)
+                }
+            }
+        }
+    }
+
     /// Deletes an entry or every duplicate data items of a key
     /// if the database supports duplicate data items.
     ///
@@ -2354,4 +2464,28 @@ pub struct DatabaseStat {
     pub overflow_pages: usize,
     /// Number of data items.
     pub entries: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use heed_types::*;
+
+    #[test]
+    fn put_overwrite() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let env = unsafe { EnvOpenOptions::new().open(dir.path())? };
+        let mut txn = env.write_txn()?;
+        let db = env.create_database::<Bytes, Bytes>(&mut txn, None)?;
+
+        assert_eq!(db.get(&txn, b"hello").unwrap(), None);
+
+        db.put(&mut txn, b"hello", b"hi").unwrap();
+        assert_eq!(db.get(&txn, b"hello").unwrap(), Some(&b"hi"[..]));
+
+        db.put(&mut txn, b"hello", b"bye").unwrap();
+        assert_eq!(db.get(&txn, b"hello").unwrap(), Some(&b"bye"[..]));
+
+        Ok(())
+    }
 }

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -1787,7 +1787,8 @@ impl<KC, DC, C> Database<KC, DC, C> {
         RwCursor::new(txn, self.dbi).map(|cursor| RwRevPrefix::new(cursor, prefix_bytes))
     }
 
-    /// Insert a key-value pair in this database. The entry is written with no specific flag.
+    /// Insert a key-value pair in this database, replacing any previous value. The entry is
+    /// written with no specific flag.
     ///
     /// ```
     /// # use std::fs;
@@ -1842,7 +1843,8 @@ impl<KC, DC, C> Database<KC, DC, C> {
         Ok(())
     }
 
-    /// Insert a key-value pair where the value can directly be written to disk.
+    /// Insert a key-value pair where the value can directly be written to disk, replacing any
+    /// previous value.
     ///
     /// ```
     /// # use std::fs;
@@ -1908,7 +1910,8 @@ impl<KC, DC, C> Database<KC, DC, C> {
         }
     }
 
-    /// Insert a key-value pair in this database. The entry is written with the specified flags.
+    /// Insert a key-value pair in this database, replacing any previous value. The entry is
+    /// written with the specified flags.
     ///
     /// ```
     /// # use std::fs;

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -2103,14 +2103,12 @@ impl<KC, DC, C> Database<KC, DC, C> {
         match result {
             // the value was successfully inserted
             Ok(()) => Ok(None),
-
             // the key already exists: the previous value is stored in the data parameter
             Err(MdbError::KeyExist) => {
                 let bytes = unsafe { crate::from_val(data_val) };
                 let data = DC::bytes_decode(bytes).map_err(Error::Decoding)?;
                 Ok(Some(data))
             }
-
             Err(error) => Err(error.into()),
         }
     }
@@ -2263,14 +2261,12 @@ impl<KC, DC, C> Database<KC, DC, C> {
                     Err(io::Error::from(io::ErrorKind::UnexpectedEof).into())
                 }
             }
-
             // the key already exists: the previous value is stored in the data parameter
             Err(MdbError::KeyExist) => {
                 let bytes = unsafe { crate::from_val(reserved) };
                 let data = DC::bytes_decode(bytes).map_err(Error::Decoding)?;
                 Ok(Some(data))
             }
-
             Err(error) => Err(error.into()),
         }
     }

--- a/heed/src/iterator/prefix.rs
+++ b/heed/src/iterator/prefix.rs
@@ -13,7 +13,7 @@ use crate::*;
 /// defined by the `C` comparator. If no successor exists (i.e. `bytes` is the maximal
 /// value), it remains unchanged and the function returns `false`. Otherwise, updates
 /// `bytes` and returns `true`.
-fn advance_prefix<C: LexicographicComparator>(bytes: &mut Vec<u8>) -> bool {
+fn advance_prefix<C: LexicographicComparator>(bytes: &mut [u8]) -> bool {
     let mut idx = bytes.len();
     while idx > 0 && bytes[idx - 1] == C::max_elem() {
         idx -= 1;
@@ -32,7 +32,7 @@ fn advance_prefix<C: LexicographicComparator>(bytes: &mut Vec<u8>) -> bool {
 /// defined by the `C` comparator. If no predecessor exists (i.e. `bytes` is the minimum
 /// value), it remains unchanged and the function returns `false`. Otherwise, updates
 /// `bytes` and returns `true`.
-fn retreat_prefix<C: LexicographicComparator>(bytes: &mut Vec<u8>) -> bool {
+fn retreat_prefix<C: LexicographicComparator>(bytes: &mut [u8]) -> bool {
     let mut idx = bytes.len();
     while idx > 0 && bytes[idx - 1] == C::min_elem() {
         idx -= 1;
@@ -49,7 +49,7 @@ fn retreat_prefix<C: LexicographicComparator>(bytes: &mut Vec<u8>) -> bool {
 
 fn move_on_prefix_end<'txn, C: LexicographicComparator>(
     cursor: &mut RoCursor<'txn>,
-    prefix: &mut Vec<u8>,
+    prefix: &mut [u8],
 ) -> Result<Option<(&'txn [u8], &'txn [u8])>> {
     if advance_prefix::<C>(prefix) {
         let result = cursor


### PR DESCRIPTION
# Pull Request

## Related issue
N/A
Based on #251 

## What does this PR do?
- Adds a new `Database::get_or_put` method which uses the `MDB_NOOVERWRITE` flag to simultaneously attempt to insert a key/value pair, or get the previous value if it already exists.
> [MDB_NOOVERWRITE](http://www.lmdb.tech/doc/group__mdb__put.html#ga23eb9813f9a4cdf7a7da5e01815b0cfb) - enter the new key/data pair only if the key does not already appear in the database. The function will return [MDB_KEYEXIST](http://www.lmdb.tech/doc/group__errors.html#ga05dc5bbcc7da81a7345bd8676e8e0e3b) if the key already appears in the database, even if the database supports duplicates ([MDB_DUPSORT](http://www.lmdb.tech/doc/group__mdb__dbi__open.html#gae0626566c2562e9007f5c8c9535bab1a)). The data parameter will be set to point to the existing item.
- This is used as an optimization over the following pattern:
```rust
if let Some(value) = db.get(&txn, key) {
    // ...
} else {
    db.put(&mut txn, key, new_value);
}
```

which can now be written as (with one fewer lookups):

```rust
if let Some(value) = db.get_or_put(&mut txn, key, new_value) {
    // ...
}
```

One drawback of the above is that it would serialize/allocate the `new_value` even if it would not end up being inserted. This can be avoided using the `get_or_put_reserved*` methods, mirroring the `put_reserved*` method.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
