### PR TITLE
Improve performance of `ReservedSpace`

### DIFF
--- a/heed/src/reserved_space.rs
+++ b/heed/src/reserved_space.rs
@@ -120,7 +120,7 @@ impl io::Write for ReservedSpace<'_> {
         unsafe {
             // SAFETY: we can always cast `T` -> `MaybeUninit<T>` as it's a transparent wrapper
             let buf_uninit = std::slice::from_raw_parts(buf.as_ptr().cast(), buf.len());
-            remaining.get_unchecked_mut(..buf.len()).copy_from_slice(buf_uninit);
+            remaining.as_mut_ptr().copy_from_nonoverlapping(buf_uninit.as_ptr(), buf.len());
         }
 
         self.write_head += buf.len();

--- a/heed/src/reserved_space.rs
+++ b/heed/src/reserved_space.rs
@@ -105,24 +105,28 @@ impl ReservedSpace<'_> {
 impl io::Write for ReservedSpace<'_> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        if self.remaining() >= buf.len() {
-            let dest = unsafe { self.bytes.as_mut_ptr().add(self.write_head) };
-            unsafe { buf.as_ptr().copy_to_nonoverlapping(dest.cast(), buf.len()) };
-            self.write_head += buf.len();
-            self.written = usize::max(self.written, self.write_head);
-            Ok(buf.len())
-        } else {
-            Err(io::Error::from(io::ErrorKind::WriteZero))
-        }
+        self.write_all(buf)?;
+        Ok(buf.len())
     }
 
     #[inline]
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        if self.write(buf)? == buf.len() {
-            Ok(())
-        } else {
-            Err(std::io::ErrorKind::WriteZero.into())
+        let remaining = &mut self.bytes[self.write_head..];
+
+        if buf.len() > remaining.len() {
+            return Err(io::Error::from(io::ErrorKind::WriteZero));
         }
+
+        // SAFETY: we can always cast `T` -> `MaybeUninit<T>` as it's a transparent wrapper
+        let buf_uninit: &[std::mem::MaybeUninit<u8>] =
+            unsafe { std::slice::from_raw_parts(buf.as_ptr().cast(), buf.len()) };
+
+        remaining[..buf.len()].copy_from_slice(buf_uninit);
+
+        self.write_head += buf.len();
+        self.written = usize::max(self.written, self.write_head);
+
+        Ok(())
     }
 
     #[inline(always)]


### PR DESCRIPTION
# Pull Request

## Related issue
Addresses (some) concerns raised in a comment: https://github.com/meilisearch/heed/pull/256#pullrequestreview-2030571441. 

## What does this PR do?
- Marks most methods of `ReservedSpace` as `#[inline]` allowing them to be inlined across crate boundaries. Especially for the `Write`-impl where callers may perform small writes, the overhead of not inlining can be significant.
- See https://github.com/Kerollmops/heed-perfs-put-reserved/pull/1 for some benchmarks and details.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
  - **Where can I find these?**
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
