### PR TITLE
Add the "mdb_maxkeysize_0" feature which sets "-DMDB_MAXKEYSIZE=0" when compiling lmdb

### DIFF
--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -90,6 +90,26 @@ mdb_idl_logn_14 = ["lmdb-master-sys/mdb_idl_logn_14"]
 mdb_idl_logn_15 = ["lmdb-master-sys/mdb_idl_logn_15"]
 mdb_idl_logn_16 = ["lmdb-master-sys/mdb_idl_logn_16"]
 
+# Setting this enables you to use keys longer than 511 bytes. The exact limit
+# is computed by LMDB at compile time. You can find the exact value by calling
+# Env::max_key_size(). This value varies by architecture.
+#
+# Example max key sizes:
+#   - Apple M1 (ARM64): 8126 bytes
+#   - Apple Intel (AMD64): 1982 bytes
+#   - Linux Intel (AMD64): 1982 bytes
+#
+# Setting this also enables you to use values larger than 511 bytes when using
+# a Database with the DatabaseFlags::DUP_SORT flag.
+#
+# This builds LMDB with the -DMDB_MAXKEYSIZE=0 option.
+#
+# Note: If you are moving database files between architectures then your longest
+# stored key must fit within the smallest limit of all architectures used. For
+# example, if you are moving databases between Apple M1 and Apple Intel
+# computers then you need to keep your keys within the smaller 1982 byte limit.
+longer-keys = ["lmdb-master-sys/longer-keys"]
+
 [[example]]
 name = "rmp-serde"
 required-features = ["serde-rmp"]

--- a/heed/src/database.rs
+++ b/heed/src/database.rs
@@ -2657,4 +2657,26 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    #[cfg(feature = "longer-keys")]
+    fn longer_keys() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let env = unsafe { EnvOpenOptions::new().open(dir.path())? };
+        let mut txn = env.write_txn()?;
+        let db = env.create_database::<Bytes, Bytes>(&mut txn, None)?;
+
+        // Try storing a key larger than 511 bytes (the default if MDB_MAXKEYSIZE is not set)
+        let long_key = b"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut pharetra sit amet aliquam. Sit amet nisl purus in mollis nunc. Eget egestas purus viverra accumsan in nisl nisi scelerisque. Duis ultricies lacus sed turpis tincidunt. Sem nulla pharetra diam sit. Leo vel orci porta non pulvinar. Erat pellentesque adipiscing commodo elit at imperdiet dui. Suspendisse ultrices gravida dictum fusce ut placerat orci nulla. Diam donec adipiscing tristique risus nec feugiat. In fermentum et sollicitudin ac orci. Ut sem nulla pharetra diam sit amet. Aliquam purus sit amet luctus venenatis lectus. Erat pellentesque adipiscing commodo elit at imperdiet dui accumsan. Urna duis convallis convallis tellus id interdum velit laoreet id. Ac feugiat sed lectus vestibulum mattis ullamcorper velit sed. Tincidunt arcu non sodales neque. Habitant morbi tristique senectus et netus et malesuada fames.";
+
+        assert_eq!(db.get(&txn, long_key).unwrap(), None);
+
+        db.put(&mut txn, long_key, b"hi").unwrap();
+        assert_eq!(db.get(&txn, long_key).unwrap(), Some(&b"hi"[..]));
+
+        db.put(&mut txn, long_key, b"bye").unwrap();
+        assert_eq!(db.get(&txn, long_key).unwrap(), Some(&b"bye"[..]));
+
+        Ok(())
+    }
 }

--- a/heed/src/mdb/lmdb_error.rs
+++ b/heed/src/mdb/lmdb_error.rs
@@ -53,6 +53,14 @@ pub enum Error {
     /// Transaction cannot recover - it must be aborted.
     BadTxn,
     /// Unsupported size of key/DB name/data, or wrong DUP_FIXED size.
+    ///
+    /// Common causes of this error:
+    ///   - You tried to store a zero-length key
+    ///   - You tried to store a key longer than the max allowed key (511 bytes by default)
+    ///   - You are using [DUP_SORT](crate::DatabaseFlags::DUP_SORT) and trying to store a
+    ///     value longer than the max allowed key size (511 bytes by default)
+    ///
+    /// In the last two cases you can enable the `longer-keys` feature to increase the max allowed key size.
     BadValSize,
     /// The specified DBI was changed unexpectedly.
     BadDbi,

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -3,11 +3,12 @@ use std::ptr;
 pub use ffi::{
     mdb_cursor_close, mdb_cursor_del, mdb_cursor_get, mdb_cursor_open, mdb_cursor_put,
     mdb_dbi_open, mdb_del, mdb_drop, mdb_env_close, mdb_env_copyfd2, mdb_env_create,
-    mdb_env_get_fd, mdb_env_get_flags, mdb_env_info, mdb_env_open, mdb_env_set_flags,
-    mdb_env_set_mapsize, mdb_env_set_maxdbs, mdb_env_set_maxreaders, mdb_env_stat, mdb_env_sync,
-    mdb_filehandle_t, mdb_get, mdb_put, mdb_reader_check, mdb_set_compare, mdb_stat, mdb_txn_abort,
-    mdb_txn_begin, mdb_txn_commit, mdb_version, MDB_cursor, MDB_dbi, MDB_env, MDB_stat, MDB_txn,
-    MDB_val, MDB_CP_COMPACT, MDB_CURRENT, MDB_RDONLY, MDB_RESERVE,
+    mdb_env_get_fd, mdb_env_get_flags, mdb_env_get_maxkeysize, mdb_env_info, mdb_env_open,
+    mdb_env_set_flags, mdb_env_set_mapsize, mdb_env_set_maxdbs, mdb_env_set_maxreaders,
+    mdb_env_stat, mdb_env_sync, mdb_filehandle_t, mdb_get, mdb_put, mdb_reader_check,
+    mdb_set_compare, mdb_stat, mdb_txn_abort, mdb_txn_begin, mdb_txn_commit, mdb_version,
+    MDB_cursor, MDB_dbi, MDB_env, MDB_stat, MDB_txn, MDB_val, MDB_CP_COMPACT, MDB_CURRENT,
+    MDB_RDONLY, MDB_RESERVE,
 };
 use lmdb_master_sys as ffi;
 

--- a/lmdb-master-sys/Cargo.toml
+++ b/lmdb-master-sys/Cargo.toml
@@ -60,3 +60,23 @@ mdb_idl_logn_13 = []
 mdb_idl_logn_14 = []
 mdb_idl_logn_15 = []
 mdb_idl_logn_16 = []
+
+# Setting this enables you to use keys longer than 511 bytes. The exact limit
+# is computed by LMDB at compile time. You can find the exact value by calling
+# Env::max_key_size(). This value varies by architecture.
+#
+# Example max key sizes:
+#   - Apple M1 (ARM64): 8126 bytes
+#   - Apple Intel (AMD64): 1982 bytes
+#   - Linux Intel (AMD64): 1982 bytes
+#
+# Setting this also enables you to use values larger than 511 bytes when using
+# a Database with the DatabaseFlags::DUP_SORT flag.
+#
+# This builds LMDB with the -DMDB_MAXKEYSIZE=0 option.
+#
+# Note: If you are moving database files between architectures then your longest
+# stored key must fit within the smallest limit of all architectures used. For
+# example, if you are moving databases between Apple M1 and Apple Intel
+# computers then you need to keep your keys within the smaller 1982 byte limit.
+longer-keys = []

--- a/lmdb-master-sys/build.rs
+++ b/lmdb-master-sys/build.rs
@@ -147,5 +147,9 @@ fn main() {
         builder.flag("-fsanitize=fuzzer-no-link");
     }
 
+    if cfg!(feature = "longer-keys") {
+        builder.define("MDB_MAXKEYSIZE", "0");
+    }
+
     builder.compile("liblmdb.a")
 }

--- a/lmdb-master-sys/tests/simple.rs
+++ b/lmdb-master-sys/tests/simple.rs
@@ -80,6 +80,17 @@ fn test_simple(env_path: &str) {
 
         E!(mdb_txn_begin(env, ptr::null_mut(), 0, &mut txn));
         E!(mdb_put(txn, dbi, &mut key, &mut data, 0));
+
+        if cfg!(feature = "longer-keys") {
+            // Try storing a key larger than 511 bytes (the default if MDB_MAXKEYSIZE is not set)
+            let sval = cstr!("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut pharetra sit amet aliquam. Sit amet nisl purus in mollis nunc. Eget egestas purus viverra accumsan in nisl nisi scelerisque. Duis ultricies lacus sed turpis tincidunt. Sem nulla pharetra diam sit. Leo vel orci porta non pulvinar. Erat pellentesque adipiscing commodo elit at imperdiet dui. Suspendisse ultrices gravida dictum fusce ut placerat orci nulla. Diam donec adipiscing tristique risus nec feugiat. In fermentum et sollicitudin ac orci. Ut sem nulla pharetra diam sit amet. Aliquam purus sit amet luctus venenatis lectus. Erat pellentesque adipiscing commodo elit at imperdiet dui accumsan. Urna duis convallis convallis tellus id interdum velit laoreet id. Ac feugiat sed lectus vestibulum mattis ullamcorper velit sed. Tincidunt arcu non sodales neque. Habitant morbi tristique senectus et netus et malesuada fames.").as_ptr() as *mut c_void;
+
+            key.mv_size = 952;
+            key.mv_data = sval;
+
+            E!(mdb_put(txn, dbi, &mut key, &mut data, 0));
+        }
+
         E!(mdb_txn_commit(txn));
     }
 


### PR DESCRIPTION
This PR (which does not have a corresponding issue) adds a `mdb_maxkeysize_0` feature to `lmdb-master-sys` and `heed` which sets `-DMDB_MAXKEYSIZE=0` when compiling LMDB. This allows you to use keys that are larger than the default of 511 bytes long.

The feature is 100% opt-in.

I've added a conditional test to `lmdb-master-sys` and `heed` to check that keys larger than 511 can be successfully stored without returning an `MDB_BAD_VALSIZE` error.

Enabling this feature also allows you to use values larger than 511 in databases with the `MDB_DUPSORT` flag set (which was the problem I was running into).

Here is the documentation snippet from http://www.lmdb.tech/doc/group__internal.html:

> #define MDB_MAXKEYSIZE   (([MDB_DEVEL](http://www.lmdb.tech/doc/group__compat.html#ga103b045068a1d21bf2347a7342f8f486)) ? 0 : 511)
>
> The max size of a key we can write, or 0 for computed max.
>
> This macro should normally be left alone or set to 0. Note that a database with big keys or dupsort data cannot be reliably modified by a liblmdb which uses a smaller max. The default is 511 for backwards compat, or 0 when [MDB_DEVEL](http://www.lmdb.tech/doc/group__compat.html#ga103b045068a1d21bf2347a7342f8f486).
>
> Other values are allowed, for backwards compat. However: A value bigger than the computed max can break if you do not know what you are doing, and liblmdb <= 0.9.10 can break when modifying a DB with keys/dupsort data bigger than its max.
>
> Data items in an [MDB_DUPSORT](http://www.lmdb.tech/doc/group__mdb__dbi__open.html#gae0626566c2562e9007f5c8c9535bab1a) database are also limited to this size, since they're actually keys of a sub-DB. Keys and [MDB_DUPSORT](http://www.lmdb.tech/doc/group__mdb__dbi__open.html#gae0626566c2562e9007f5c8c9535bab1a) data items must fit on a node in a regular page.
