### PR TITLE
fix function docs (clippy warnings)

### DIFF
--- a/heed/src/cursor.rs
+++ b/heed/src/cursor.rs
@@ -260,7 +260,7 @@ impl<'txn> RwCursor<'txn> {
     /// while modifying it.
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn del_current(&mut self) -> Result<bool> {
@@ -294,7 +294,7 @@ impl<'txn> RwCursor<'txn> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current(&mut self, key: &[u8], data: &[u8]) -> Result<bool> {
@@ -377,7 +377,7 @@ impl<'txn> RwCursor<'txn> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current_with_flags(

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -765,9 +765,9 @@ impl Env {
     ///
     /// * [`crate::MdbError::Panic`]: A fatal error occurred earlier, and the environment must be shut down
     /// * [`crate::MdbError::MapResized`]: Another process wrote data beyond this [`Env`] mapsize and this env
-    /// map must be resized
+    ///   map must be resized
     /// * [`crate::MdbError::ReadersFull`]: a read-only transaction was requested, and the reader lock table is
-    /// full
+    ///   full
     pub fn read_txn(&self) -> Result<RoTxn> {
         RoTxn::new(self)
     }
@@ -794,9 +794,9 @@ impl Env {
     ///
     /// * [`crate::MdbError::Panic`]: A fatal error occurred earlier, and the environment must be shut down
     /// * [`crate::MdbError::MapResized`]: Another process wrote data beyond this [`Env`] mapsize and this env
-    /// map must be resized
+    ///   map must be resized
     /// * [`crate::MdbError::ReadersFull`]: a read-only transaction was requested, and the reader lock table is
-    /// full
+    ///   full
     pub fn static_read_txn(self) -> Result<RoTxn<'static>> {
         RoTxn::static_read_txn(self)
     }

--- a/heed/src/iterator/iter.rs
+++ b/heed/src/iterator/iter.rs
@@ -233,7 +233,7 @@ impl<'txn, KC, DC, IM> RwIter<'txn, KC, DC, IM> {
     /// while modifying it.
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn del_current(&mut self) -> Result<bool> {
@@ -260,7 +260,7 @@ impl<'txn, KC, DC, IM> RwIter<'txn, KC, DC, IM> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current<'a>(
@@ -319,7 +319,7 @@ impl<'txn, KC, DC, IM> RwIter<'txn, KC, DC, IM> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current_with_options<'a, NDC>(
@@ -582,7 +582,7 @@ impl<'txn, KC, DC, IM> RwRevIter<'txn, KC, DC, IM> {
     /// while modifying it.
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn del_current(&mut self) -> Result<bool> {
@@ -609,7 +609,7 @@ impl<'txn, KC, DC, IM> RwRevIter<'txn, KC, DC, IM> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current<'a>(
@@ -668,7 +668,7 @@ impl<'txn, KC, DC, IM> RwRevIter<'txn, KC, DC, IM> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current_with_options<'a, NDC>(

--- a/heed/src/iterator/prefix.rs
+++ b/heed/src/iterator/prefix.rs
@@ -226,7 +226,7 @@ impl<'txn, KC, DC, C, IM> RwPrefix<'txn, KC, DC, C, IM> {
     /// while modifying it.
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn del_current(&mut self) -> Result<bool> {
@@ -253,7 +253,7 @@ impl<'txn, KC, DC, C, IM> RwPrefix<'txn, KC, DC, C, IM> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current<'a>(
@@ -312,7 +312,7 @@ impl<'txn, KC, DC, C, IM> RwPrefix<'txn, KC, DC, C, IM> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current_with_options<'a, NDC>(
@@ -616,7 +616,7 @@ impl<'txn, KC, DC, C, IM> RwRevPrefix<'txn, KC, DC, C, IM> {
     /// while modifying it.
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn del_current(&mut self) -> Result<bool> {
@@ -643,7 +643,7 @@ impl<'txn, KC, DC, C, IM> RwRevPrefix<'txn, KC, DC, C, IM> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current<'a>(
@@ -702,7 +702,7 @@ impl<'txn, KC, DC, C, IM> RwRevPrefix<'txn, KC, DC, C, IM> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current_with_options<'a, NDC>(

--- a/heed/src/iterator/range.rs
+++ b/heed/src/iterator/range.rs
@@ -235,7 +235,7 @@ impl<'txn, KC, DC, IM> RwRange<'txn, KC, DC, IM> {
     /// while modifying it.
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn del_current(&mut self) -> Result<bool> {
@@ -262,7 +262,7 @@ impl<'txn, KC, DC, IM> RwRange<'txn, KC, DC, IM> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current<'a>(
@@ -321,7 +321,7 @@ impl<'txn, KC, DC, IM> RwRange<'txn, KC, DC, IM> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current_with_options<'a, NDC>(
@@ -672,7 +672,7 @@ impl<'txn, KC, DC, IM> RwRevRange<'txn, KC, DC, IM> {
     /// while modifying it.
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn del_current(&mut self) -> Result<bool> {
@@ -699,7 +699,7 @@ impl<'txn, KC, DC, IM> RwRevRange<'txn, KC, DC, IM> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current<'a>(
@@ -758,7 +758,7 @@ impl<'txn, KC, DC, IM> RwRevRange<'txn, KC, DC, IM> {
     /// version of them (e.g. `&str` into `String`).
     ///
     /// > [Values returned from the database are valid only until a subsequent update operation,
-    /// or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val).
+    /// > or the end of the transaction.](http://www.lmdb.tech/doc/group__mdb.html#structMDB__val)
     ///
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     pub unsafe fn put_current_with_options<'a, NDC>(


### PR DESCRIPTION
# Pull Request


## What does this PR do?
Fixes formatting in some function's documentation. Clippy (`cargo clippy`) reported all of them apart from the quotes ending with two `.`s.
