### PR TITLE
fix custom_key_cmp_wrapper being able to unwind to C code (ub)

### DIFF
--- a/heed-traits/src/lib.rs
+++ b/heed-traits/src/lib.rs
@@ -42,11 +42,6 @@ pub trait BytesDecode<'a> {
 /// with shorter keys collating before longer keys.
 pub trait Comparator {
     /// Compares the raw bytes representation of two keys.
-    ///
-    /// # Safety
-    ///
-    /// This function must never crash, this is the reason why it takes raw bytes as parameter,
-    /// to let you define the recovery method you want in case of a decoding error.
     fn compare(a: &[u8], b: &[u8]) -> Ordering;
 }
 
@@ -61,10 +56,6 @@ pub trait Comparator {
 pub trait LexicographicComparator: Comparator {
     /// Compare a single byte; this function is used to implement [`Comparator::compare`]
     /// by definition of lexicographic ordering.
-    ///
-    /// # Safety
-    ///
-    /// This function must never crash.
     fn compare_elem(a: u8, b: u8) -> Ordering;
 
     /// Advances the given `elem` to its immediate lexicographic successor, if possible.

--- a/heed/src/env.rs
+++ b/heed/src/env.rs
@@ -373,6 +373,12 @@ impl Drop for EnvInner {
 
 /// A helper function that transforms the LMDB types into Rust types (`MDB_val` into slices)
 /// and vice versa, the Rust types into C types (`Ordering` into an integer).
+///
+/// # Safety
+///
+/// `a` and `b` should both properly aligned, valid for reads and should point to a valid
+/// [`MDB_val`][ffi::MDB_val]. An [`MDB_val`][ffi::MDB_val] (consists of a pointer and size) is
+/// valid when its pointer (`mv_data`) is valid for reads of `mv_size` bytes and is not null.
 unsafe extern "C" fn custom_key_cmp_wrapper<C: Comparator>(
     a: *const ffi::MDB_val,
     b: *const ffi::MDB_val,


### PR DESCRIPTION
`custom_key_cmp_wrapper` may not panic because it is called from C code that does not understand rust panics. If it does, that is undefined behavior.

`custom_key_cmp_wrapper` will now abort if the Comparator implementation panics. I also removed the safety comments on `compare` and `compare_elem` (the safety comments on the safe trait is what got me to discover this UB)

Review note:
```rust
match ord {
    Ordering::Less => -1,
    Ordering::Equal => 0,
    Ordering::Greater => 1,
}
```
is equivalent to `ord as i32`