### PR TITLE
feat: add `dup_sort_comparator`

### DIFF
--- a/heed/examples/custom-dupsort-comparator.rs
+++ b/heed/examples/custom-dupsort-comparator.rs
@@ -1,0 +1,62 @@
+use std::cmp::Ordering;
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+use byteorder::BigEndian;
+use heed::{DatabaseFlags, EnvOpenOptions};
+use heed_traits::Comparator;
+use heed_types::{Str, U128};
+
+enum DescendingIntCmp {}
+
+impl Comparator for DescendingIntCmp {
+    fn compare(a: &[u8], b: &[u8]) -> Ordering {
+        b.cmp(&a)
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let env_path = Path::new("target").join("custom-dupsort-cmp.mdb");
+
+    let _ = fs::remove_dir_all(&env_path);
+
+    fs::create_dir_all(&env_path)?;
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024) // 10MB
+            .max_dbs(3)
+            .open(env_path)?
+    };
+
+    let mut wtxn = env.write_txn()?;
+    let db = env
+        .database_options()
+        .types::<Str, U128<BigEndian>>()
+        .flags(DatabaseFlags::DUP_SORT)
+        .dup_sort_comparator::<DescendingIntCmp>()
+        .create(&mut wtxn)?;
+    wtxn.commit()?;
+
+    let mut wtxn = env.write_txn()?;
+
+    // We fill our database with entries.
+    db.put(&mut wtxn, "1", &1)?;
+    db.put(&mut wtxn, "1", &2)?;
+    db.put(&mut wtxn, "1", &3)?;
+    db.put(&mut wtxn, "2", &4)?;
+    db.put(&mut wtxn, "1", &5)?;
+    db.put(&mut wtxn, "0", &0)?;
+
+    // We check that the keys are in lexicographic and values in descending order.
+    let mut iter = db.iter(&wtxn)?;
+    assert_eq!(iter.next().transpose()?, Some(("0", 0)));
+    assert_eq!(iter.next().transpose()?, Some(("1", 5)));
+    assert_eq!(iter.next().transpose()?, Some(("1", 3)));
+    assert_eq!(iter.next().transpose()?, Some(("1", 2)));
+    assert_eq!(iter.next().transpose()?, Some(("1", 1)));
+    assert_eq!(iter.next().transpose()?, Some(("2", 4)));
+    drop(iter);
+
+    Ok(())
+}

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -6,9 +6,9 @@ pub use ffi::{
     mdb_env_get_fd, mdb_env_get_flags, mdb_env_get_maxkeysize, mdb_env_info, mdb_env_open,
     mdb_env_set_flags, mdb_env_set_mapsize, mdb_env_set_maxdbs, mdb_env_set_maxreaders,
     mdb_env_stat, mdb_env_sync, mdb_filehandle_t, mdb_get, mdb_put, mdb_reader_check,
-    mdb_set_compare, mdb_stat, mdb_txn_abort, mdb_txn_begin, mdb_txn_commit, mdb_version,
-    MDB_cursor, MDB_dbi, MDB_env, MDB_stat, MDB_txn, MDB_val, MDB_CP_COMPACT, MDB_CURRENT,
-    MDB_RDONLY, MDB_RESERVE,
+    mdb_set_compare, mdb_set_dupsort, mdb_stat, mdb_txn_abort, mdb_txn_begin, mdb_txn_commit,
+    mdb_version, MDB_cursor, MDB_dbi, MDB_env, MDB_stat, MDB_txn, MDB_val, MDB_CP_COMPACT,
+    MDB_CURRENT, MDB_RDONLY, MDB_RESERVE,
 };
 use lmdb_master_sys as ffi;
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?

Expose http://www.lmdb.tech/doc/group__internal.html#gacef4ec3dab0bbd9bc978b73c19c879ae via new `dup_sort_comparator` function to set a custom `Comparator`.

It basically works like `key_comparator`, except that for calling `mdb_set_compare` it calls `mdb_set_dupsort` on the database.

It can be used like this:

```rust
enum DescendingIntCmp {}

impl Comparator for DescendingIntCmp {
    fn compare(a: &[u8], b: &[u8]) -> Ordering {
        b.cmp(&a)
    }
}

//

let db = env
    .database_options()
    .types::<Str, U128<BigEndian>>()
    .flags(DatabaseFlags::DUP_SORT)
    .dup_sort_comparator::<DescendingIntCmp>()
    .create(&mut wtxn)?;
```

Also added an example and updated the cookbook (resolves #284).