### PR TITLE
add custom ordering support to range types

### DIFF
--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -82,7 +82,7 @@ use self::cursor::{RoCursor, RwCursor};
 pub use self::database::{Database, DatabaseOpenOptions, DatabaseStat};
 pub use self::env::{
     env_closing_event, CompactionOption, DefaultComparator, Env, EnvClosingEvent, EnvInfo,
-    EnvOpenOptions, FlagSetMode,
+    EnvOpenOptions, FlagSetMode, IntegerComparator,
 };
 pub use self::iterator::{
     RoIter, RoPrefix, RoRange, RoRevIter, RoRevPrefix, RoRevRange, RwIter, RwPrefix, RwRange,

--- a/heed/src/mdb/lmdb_flags.rs
+++ b/heed/src/mdb/lmdb_flags.rs
@@ -43,6 +43,9 @@ bitflags! {
         const DUP_SORT = ffi::MDB_DUPSORT;
         /// Numeric keys in native byte order: either `u32` or `usize`.
         /// The keys must all be of the same size.
+        ///
+        /// It is recommended to set the comparator to [`IntegerComparator`](crate::IntegerComparator),
+        /// rather than setting this flag manually.
         const INTEGER_KEY = ffi::MDB_INTEGERKEY;
         /// With [`DatabaseFlags::DUP_SORT`], sorted dup items have fixed size.
         const DUP_FIXED = ffi::MDB_DUPFIXED;


### PR DESCRIPTION
## What does this PR do?

This PR adds custom ordering support to the `iterator/range` types, by using the `Comparator` trait. Without this PR using any of the `range` functions on `Database` when a custom ordering is set will give unexpected results, like not giving all the keys in the range.

This PR also adds a `IntegerComparator` type, which represents the ordering when the `MDB_INTEGERKEY` flag is set. This is needed to allow the range functions to work when a table sets that flag.



