### PR TITLE
Upgrade heed3 dependencies

### DIFF
--- a/heed3/Cargo.toml
+++ b/heed3/Cargo.toml
@@ -15,26 +15,24 @@ include = [
 ]
 
 [dependencies]
-# TODO update dependencies
 aead = { version = "0.5.2", default-features = false }
 bitflags = { version = "2.6.0", features = ["serde"] }
 byteorder = { version = "1.5.0", default-features = false }
 generic-array = { version = "0.14.7", features = ["serde"] }
 heed-traits = { version = "0.20.0", path = "../heed-traits" }
 heed-types = { version = "0.21.0", default-features = false, path = "../heed-types" }
-libc = "0.2.167"
+libc = "0.2.169"
 lmdb-master3-sys = { version = "0.2.4", path = "../lmdb-master3-sys" }
 once_cell = "1.20.2"
 page_size = "0.6.0"
-serde = { version = "1.0.215", features = ["derive"], optional = true }
+serde = { version = "1.0.217", features = ["derive"], optional = true }
 synchronoise = "1.0.1"
 
 [dev-dependencies]
-# TODO update dependencies
 argon2 = { version = "0.5.3", features = ["std"] }
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.217", features = ["derive"] }
 chacha20poly1305 = "0.10.1"
-tempfile = "3.14.0"
+tempfile = "3.15.0"
 
 [target.'cfg(windows)'.dependencies]
 url = "2.5.4"


### PR DESCRIPTION
Upgrade compatible and incompatible dependencies of heed3.

Note that I couldn't bump the `generic-array` dependency as the other ones use an old version.