### PR TITLE
Allow nested rtxn from wtxn for v0.20

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lmdb-master-sys/lmdb"]
 	path = lmdb-master-sys/lmdb
-	url = https://github.com/LMDB/lmdb
-	branch = mdb.master
+	url = https://github.com/meilisearch/lmdb.git
+	branch = allow-nested-rtxn-from-wtxn

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -64,6 +64,10 @@ arbitrary_precision = ["heed-types/arbitrary_precision"]
 raw_value = ["heed-types/raw_value"]
 unbounded_depth = ["heed-types/unbounded_depth"]
 
+asan = ["lmdb-master-sys/asan"]
+fuzzer = ["lmdb-master-sys/fuzzer"]
+fuzzer-no-link = ["lmdb-master-sys/fuzzer-no-link"]
+
 # Whether to tell LMDB to use POSIX semaphores during compilation
 # (instead of the default, which are System V semaphores).
 # POSIX semaphores are required for Apple's App Sandbox on iOS & macOS,

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -73,6 +73,18 @@ unbounded_depth = ["heed-types/unbounded_depth"]
 # <https://github.com/LMDB/lmdb/blob/3947014aed7ffe39a79991fa7fb5b234da47ad1a/libraries/liblmdb/lmdb.h#L46-L69>
 posix-sem = ["lmdb-master-sys/posix-sem"]
 
+# Prints debugging information on stderr.
+debug-simple = ["lmdb-master-sys/debug-simple"]
+# Add copious tracing. It enables the debug-simple feature.
+debug-copious-tracing = ["lmdb-master-sys/debug-copious-tracing"]
+# Add dumps of all IDLs read from and written to the database
+# (used for free space management). It enables the debug-simple
+# and debug-dump-idls features.
+debug-dump-idls = ["lmdb-master-sys/debug-dump-idls"]
+# Do an audit after each commit. It enables the debug-simple,
+# debug-copious-tracing, and debug-dump-idls features.
+debug-audit-commit = ["lmdb-master-sys/debug-audit-commit"]
+
 # These features configure the MDB_IDL_LOGN macro, which determines
 # the size of the free and dirty page lists (and thus the amount of memory
 # allocated when opening an LMDB environment in read-write mode).

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heed"
-version = "0.20.4"
+version = "0.20.5"
 authors = ["Kerollmops <renault.cle@gmail.com>"]
 description = "A fully typed LMDB wrapper with minimum overhead"
 license = "MIT"

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -23,8 +23,11 @@ serde = { version = "1.0.203", features = ["derive"], optional = true }
 synchronoise = "1.0.1"
 
 [dev-dependencies]
-serde = { version = "1.0.203", features = ["derive"] }
-tempfile = "3.10.1"
+rand = "0.9.0"
+rayon = "1.10.0"
+roaring = "0.10.10"
+serde = { version = "1.0.217", features = ["derive"] }
+tempfile = "3.15.0"
 
 [target.'cfg(windows)'.dependencies]
 url = "2.5.2"
@@ -109,6 +112,10 @@ mdb_idl_logn_16 = ["lmdb-master-sys/mdb_idl_logn_16"]
 # example, if you are moving databases between Apple M1 and Apple Intel
 # computers then you need to keep your keys within the smaller 1982 byte limit.
 longer-keys = ["lmdb-master-sys/longer-keys"]
+
+[[example]]
+name = "nested-rtxns"
+required-features = ["read-txn-no-tls"]
 
 [[example]]
 name = "rmp-serde"

--- a/heed/examples/nested-rtxns.rs
+++ b/heed/examples/nested-rtxns.rs
@@ -1,0 +1,77 @@
+use heed::types::*;
+use heed::{Database, EnvOpenOptions};
+use rand::prelude::*;
+use rayon::prelude::*;
+use roaring::RoaringBitmap;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .map_size(2 * 1024 * 1024 * 1024) // 2 GiB
+            .open(dir.path())?
+    };
+
+    // opening a write transaction
+    let mut wtxn = env.write_txn()?;
+    // we will open the default unnamed database
+    let db: Database<U32<byteorder::BigEndian>, Bytes> = env.create_database(&mut wtxn, None)?;
+
+    let mut buffer = Vec::new();
+    for i in 0..1000 {
+        let mut rng = StdRng::seed_from_u64(i as u64);
+        let max = rng.random_range(10_000..=100_000);
+        let roaring = RoaringBitmap::from_sorted_iter(0..max)?;
+        buffer.clear();
+        roaring.serialize_into(&mut buffer)?;
+        db.put(&mut wtxn, &i, &buffer)?;
+    }
+
+    // opening multiple read-only transactions
+    // to check if those values are now available
+    // without committing beforehand
+    let rtxns = (0..1000).map(|_| env.nested_read_txn(&wtxn)).collect::<heed::Result<Vec<_>>>()?;
+
+    rtxns.into_par_iter().enumerate().for_each(|(i, rtxn)| {
+        let mut rng = StdRng::seed_from_u64(i as u64);
+        let max = rng.random_range(10_000..=100_000);
+        let roaring = RoaringBitmap::from_sorted_iter(0..max).unwrap();
+
+        let mut buffer = Vec::new();
+        roaring.serialize_into(&mut buffer).unwrap();
+
+        let i = i as u32;
+        let ret = db.get(&rtxn, &i).unwrap();
+        assert_eq!(ret, Some(&buffer[..]));
+    });
+
+    for i in 1000..10_000 {
+        let mut rng = StdRng::seed_from_u64(i as u64);
+        let max = rng.random_range(10_000..=100_000);
+        let roaring = RoaringBitmap::from_sorted_iter(0..max)?;
+        buffer.clear();
+        roaring.serialize_into(&mut buffer)?;
+        db.put(&mut wtxn, &i, &buffer)?;
+    }
+
+    // opening multiple read-only transactions
+    // to check if those values are now available
+    // without committing beforehand
+    let rtxns =
+        (1000..10_000).map(|_| env.nested_read_txn(&wtxn)).collect::<heed::Result<Vec<_>>>()?;
+
+    rtxns.into_par_iter().enumerate().for_each(|(i, rtxn)| {
+        let mut rng = StdRng::seed_from_u64(i as u64);
+        let max = rng.random_range(10_000..=100_000);
+        let roaring = RoaringBitmap::from_sorted_iter(0..max).unwrap();
+
+        let mut buffer = Vec::new();
+        roaring.serialize_into(&mut buffer).unwrap();
+
+        let i = i as u32;
+        let ret = db.get(&rtxn, &i).unwrap();
+        assert_eq!(ret, Some(&buffer[..]));
+    });
+
+    Ok(())
+}

--- a/lmdb-master-sys/Cargo.toml
+++ b/lmdb-master-sys/Cargo.toml
@@ -27,7 +27,9 @@ doctest = false
 libc = "0.2.155"
 
 [build-dependencies]
-bindgen = { version = "0.69.4", default-features = false, optional = true, features = ["runtime"] }
+bindgen = { version = "0.69.4", default-features = false, optional = true, features = [
+    "runtime",
+] }
 cc = "1.0.104"
 doxygen-rs = "0.4.2"
 
@@ -40,6 +42,18 @@ asan = []
 fuzzer = []
 fuzzer-no-link = []
 posix-sem = []
+
+# Prints debugging information on stderr.
+debug-simple = []
+# Add copious tracing. It enables the debug-simple feature.
+debug-copious-tracing = []
+# Add dumps of all IDLs read from and written to the database
+# (used for free space management). It enables the debug-simple
+# and debug-dump-idls features.
+debug-dump-idls = []
+# Do an audit after each commit. It enables the debug-simple,
+# debug-copious-tracing, and debug-dump-idls features.
+debug-audit-commit = []
 
 # These features configure the MDB_IDL_LOGN macro, which determines
 # the size of the free and dirty page lists (and thus the amount of memory

--- a/lmdb-master-sys/build.rs
+++ b/lmdb-master-sys/build.rs
@@ -169,6 +169,7 @@ fn main() {
 
     if cfg!(feature = "asan") {
         builder.flag("-fsanitize=address");
+        builder.flag("-static-libasan");
     }
 
     if cfg!(feature = "fuzzer") {


### PR DESCRIPTION
This PR must not be merged as it is superseded by #307, which is much cleaner. This other one uses the runtime `WithTls` and `WithoutTls` types. The base branch is not even where I want to merge this.