### PR TITLE
Introduce `AnyTls`

### DIFF
--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -424,7 +424,7 @@
 //! }
 //!
 //! impl<'t> ImmutableMap<'t> {
-//!     fn from_db<T>(rtxn: &'t RoTxn<T>, db: Database<Str, Str>) -> heed::Result<Self> {
+//!     fn from_db(rtxn: &'t RoTxn, db: Database<Str, Str>) -> heed::Result<Self> {
 //!         let mut map = HashMap::new();
 //!         for result in db.iter(rtxn)? {
 //!             let (k, v) = result?;

--- a/heed/src/cursor.rs
+++ b/heed/src/cursor.rs
@@ -11,8 +11,7 @@ pub struct RoCursor<'txn> {
 }
 
 impl<'txn> RoCursor<'txn> {
-    // TODO should I ask for a &mut RoTxn<'_, T>, here?
-    pub(crate) fn new<T>(txn: &'txn RoTxn<'_, T>, dbi: ffi::MDB_dbi) -> Result<RoCursor<'txn>> {
+    pub(crate) fn new<T>(txn: &'txn RoTxn<T>, dbi: ffi::MDB_dbi) -> Result<RoCursor<'txn>> {
         let mut cursor: *mut ffi::MDB_cursor = ptr::null_mut();
         let mut txn = txn.txn_ptr();
         unsafe { mdb_result(ffi::mdb_cursor_open(txn.as_mut(), dbi, &mut cursor))? }

--- a/heed/src/cursor.rs
+++ b/heed/src/cursor.rs
@@ -14,7 +14,7 @@ impl<'txn, T> RoCursor<'txn, T> {
     // TODO should I ask for a &mut RoTxn<'_, T>, here?
     pub(crate) fn new(txn: &'txn RoTxn<'_, T>, dbi: ffi::MDB_dbi) -> Result<RoCursor<'txn, T>> {
         let mut cursor: *mut ffi::MDB_cursor = ptr::null_mut();
-        let mut txn = txn.txn.unwrap();
+        let mut txn = txn.txn_ptr();
         unsafe { mdb_result(ffi::mdb_cursor_open(txn.as_mut(), dbi, &mut cursor))? }
         Ok(RoCursor { cursor, _marker: marker::PhantomData })
     }

--- a/heed/src/databases/database.rs
+++ b/heed/src/databases/database.rs
@@ -132,7 +132,7 @@ impl<'e, 'n, T, KC, DC, C> DatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
     ///
     /// If not done, you might raise `Io(Os { code: 22, kind: InvalidInput, message: "Invalid argument" })`
     /// known as `EINVAL`.
-    pub fn open(&self, rtxn: &RoTxn<T>) -> Result<Option<Database<KC, DC, C>>>
+    pub fn open(&self, rtxn: &RoTxn) -> Result<Option<Database<KC, DC, C>>>
     where
         KC: 'static,
         DC: 'static,
@@ -172,13 +172,13 @@ impl<'e, 'n, T, KC, DC, C> DatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
     }
 }
 
-impl<KC, DC, C> Clone for DatabaseOpenOptions<'_, '_, KC, DC, C> {
+impl<T, KC, DC, C> Clone for DatabaseOpenOptions<'_, '_, T, KC, DC, C> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<KC, DC, C> Copy for DatabaseOpenOptions<'_, '_, KC, DC, C> {}
+impl<T, KC, DC, C> Copy for DatabaseOpenOptions<'_, '_, T, KC, DC, C> {}
 
 /// A typed database that accepts only the types it was created with.
 ///
@@ -340,11 +340,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get<'a, 'txn, T>(
-        &self,
-        txn: &'txn RoTxn<T>,
-        key: &'a KC::EItem,
-    ) -> Result<Option<DC::DItem>>
+    pub fn get<'a, 'txn>(&self, txn: &'txn RoTxn, key: &'a KC::EItem) -> Result<Option<DC::DItem>>
     where
         KC: BytesEncode<'a>,
         DC: BytesDecode<'txn>,
@@ -429,9 +425,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_duplicates<'a, 'txn, T>(
+    pub fn get_duplicates<'a, 'txn>(
         &self,
-        txn: &'txn RoTxn<T>,
+        txn: &'txn RoTxn,
         key: &'a KC::EItem,
     ) -> Result<Option<RoIter<'txn, KC, DC, MoveOnCurrentKeyDuplicates>>>
     where
@@ -492,9 +488,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_lower_than<'a, 'txn, T>(
+    pub fn get_lower_than<'a, 'txn>(
         &self,
-        txn: &'txn RoTxn<T>,
+        txn: &'txn RoTxn,
         key: &'a KC::EItem,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
@@ -561,9 +557,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_lower_than_or_equal_to<'a, 'txn, T>(
+    pub fn get_lower_than_or_equal_to<'a, 'txn>(
         &self,
-        txn: &'txn RoTxn<T>,
+        txn: &'txn RoTxn,
         key: &'a KC::EItem,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
@@ -634,9 +630,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_greater_than<'a, 'txn, T>(
+    pub fn get_greater_than<'a, 'txn>(
         &self,
-        txn: &'txn RoTxn<T>,
+        txn: &'txn RoTxn,
         key: &'a KC::EItem,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
@@ -706,9 +702,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_greater_than_or_equal_to<'a, 'txn, T>(
+    pub fn get_greater_than_or_equal_to<'a, 'txn>(
         &self,
-        txn: &'txn RoTxn<T>,
+        txn: &'txn RoTxn,
         key: &'a KC::EItem,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
@@ -765,7 +761,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn first<'txn, T>(&self, txn: &'txn RoTxn<T>) -> Result<Option<(KC::DItem, DC::DItem)>>
+    pub fn first<'txn>(&self, txn: &'txn RoTxn) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
         KC: BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
@@ -819,7 +815,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn last<'txn, T>(&self, txn: &'txn RoTxn<T>) -> Result<Option<(KC::DItem, DC::DItem)>>
+    pub fn last<'txn>(&self, txn: &'txn RoTxn) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
         KC: BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
@@ -876,7 +872,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn len<T>(&self, txn: &RoTxn<T>) -> Result<u64> {
+    pub fn len(&self, txn: &RoTxn) -> Result<u64> {
         self.stat(txn).map(|stat| stat.entries as u64)
     }
 
@@ -919,7 +915,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn is_empty<T>(&self, txn: &RoTxn<T>) -> Result<bool> {
+    pub fn is_empty(&self, txn: &RoTxn) -> Result<bool> {
         self.len(txn).map(|l| l == 0)
     }
 
@@ -961,7 +957,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn stat<T>(&self, txn: &RoTxn<T>) -> Result<DatabaseStat> {
+    pub fn stat(&self, txn: &RoTxn) -> Result<DatabaseStat> {
         assert_eq_env_db_txn!(self, txn);
 
         let mut db_stat = mem::MaybeUninit::uninit();
@@ -1026,7 +1022,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn iter<'txn, T>(&self, txn: &'txn RoTxn<T>) -> Result<RoIter<'txn, KC, DC>> {
+    pub fn iter<'txn>(&self, txn: &'txn RoTxn) -> Result<RoIter<'txn, KC, DC>> {
         assert_eq_env_db_txn!(self, txn);
         RoCursor::new(txn, self.dbi).map(|cursor| RoIter::new(cursor))
     }
@@ -1128,7 +1124,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_iter<'txn, T>(&self, txn: &'txn RoTxn<T>) -> Result<RoRevIter<'txn, KC, DC>> {
+    pub fn rev_iter<'txn>(&self, txn: &'txn RoTxn) -> Result<RoRevIter<'txn, KC, DC>> {
         assert_eq_env_db_txn!(self, txn);
 
         RoCursor::new(txn, self.dbi).map(|cursor| RoRevIter::new(cursor))
@@ -1235,9 +1231,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn range<'a, 'txn, R, T>(
+    pub fn range<'a, 'txn, R>(
         &self,
-        txn: &'txn RoTxn<T>,
+        txn: &'txn RoTxn,
         range: &'a R,
     ) -> Result<RoRange<'txn, KC, DC, C>>
     where
@@ -1408,9 +1404,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_range<'a, 'txn, R, T>(
+    pub fn rev_range<'a, 'txn, R>(
         &self,
-        txn: &'txn RoTxn<T>,
+        txn: &'txn RoTxn,
         range: &'a R,
     ) -> Result<RoRevRange<'txn, KC, DC, C>>
     where
@@ -1583,9 +1579,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn prefix_iter<'a, 'txn, T>(
+    pub fn prefix_iter<'a, 'txn>(
         &self,
-        txn: &'txn RoTxn<T>,
+        txn: &'txn RoTxn,
         prefix: &'a KC::EItem,
     ) -> Result<RoPrefix<'txn, KC, DC, C>>
     where
@@ -1716,9 +1712,9 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_prefix_iter<'a, 'txn, T>(
+    pub fn rev_prefix_iter<'a, 'txn>(
         &self,
-        txn: &'txn RoTxn<'_, T>,
+        txn: &'txn RoTxn,
         prefix: &'a KC::EItem,
     ) -> Result<RoRevPrefix<'txn, KC, DC, C>>
     where

--- a/heed/src/databases/database.rs
+++ b/heed/src/databases/database.rs
@@ -140,7 +140,7 @@ impl<'e, 'n, T, KC, DC, C> DatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
     {
         assert_eq_env_txn!(self.env, rtxn);
 
-        match self.env.raw_init_database::<C>(rtxn.txn.unwrap(), self.name, self.flags) {
+        match self.env.raw_init_database::<C>(rtxn.txn_ptr(), self.name, self.flags) {
             Ok(dbi) => Ok(Some(Database::new(self.env.env_mut_ptr().as_ptr() as _, dbi))),
             Err(Error::Mdb(e)) if e.not_found() => Ok(None),
             Err(e) => Err(e),
@@ -165,7 +165,7 @@ impl<'e, 'n, T, KC, DC, C> DatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
         assert_eq_env_txn!(self.env, wtxn);
 
         let flags = self.flags | AllDatabaseFlags::CREATE;
-        match self.env.raw_init_database::<C>(wtxn.txn.txn.unwrap(), self.name, flags) {
+        match self.env.raw_init_database::<C>(wtxn.txn_ptr(), self.name, flags) {
             Ok(dbi) => Ok(Database::new(self.env.env_mut_ptr().as_ptr() as _, dbi)),
             Err(e) => Err(e),
         }
@@ -358,7 +358,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
 
         let result = unsafe {
             mdb_result(ffi::mdb_get(
-                txn.txn.unwrap().as_mut(),
+                txn.txn_ptr().as_mut(),
                 self.dbi,
                 &mut key_val,
                 data_val.as_mut_ptr(),
@@ -966,7 +966,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
 
         let mut db_stat = mem::MaybeUninit::uninit();
         let result = unsafe {
-            mdb_result(ffi::mdb_stat(txn.txn.unwrap().as_mut(), self.dbi, db_stat.as_mut_ptr()))
+            mdb_result(ffi::mdb_stat(txn.txn_ptr().as_mut(), self.dbi, db_stat.as_mut_ptr()))
         };
 
         match result {
@@ -1854,7 +1854,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
 
         unsafe {
             mdb_result(ffi::mdb_put(
-                txn.txn.txn.unwrap().as_mut(),
+                txn.txn_ptr().as_mut(),
                 self.dbi,
                 &mut key_val,
                 &mut data_val,
@@ -1921,7 +1921,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
 
         unsafe {
             mdb_result(ffi::mdb_put(
-                txn.txn.txn.unwrap().as_mut(),
+                txn.txn_ptr().as_mut(),
                 self.dbi,
                 &mut key_val,
                 &mut reserved,
@@ -2019,7 +2019,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
 
         unsafe {
             mdb_result(ffi::mdb_put(
-                txn.txn.txn.unwrap().as_mut(),
+                txn.txn_ptr().as_mut(),
                 self.dbi,
                 &mut key_val,
                 &mut data_val,
@@ -2132,7 +2132,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
 
         let result = unsafe {
             mdb_result(ffi::mdb_put(
-                txn.txn.txn.unwrap().as_mut(),
+                txn.txn_ptr().as_mut(),
                 self.dbi,
                 &mut key_val,
                 &mut data_val,
@@ -2288,7 +2288,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
 
         let result = unsafe {
             mdb_result(ffi::mdb_put(
-                txn.txn.txn.unwrap().as_mut(),
+                txn.txn.txn_ptr().as_mut(),
                 self.dbi,
                 &mut key_val,
                 &mut reserved,
@@ -2371,7 +2371,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
 
         let result = unsafe {
             mdb_result(ffi::mdb_del(
-                txn.txn.txn.unwrap().as_mut(),
+                txn.txn.txn_ptr().as_mut(),
                 self.dbi,
                 &mut key_val,
                 ptr::null_mut(),
@@ -2463,7 +2463,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
 
         let result = unsafe {
             mdb_result(ffi::mdb_del(
-                txn.txn.txn.unwrap().as_mut(),
+                txn.txn.txn_ptr().as_mut(),
                 self.dbi,
                 &mut key_val,
                 &mut data_val,
@@ -2593,8 +2593,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
         assert_eq_env_db_txn!(self, txn);
 
         unsafe {
-            mdb_result(ffi::mdb_drop(txn.txn.txn.unwrap().as_mut(), self.dbi, 0))
-                .map_err(Into::into)
+            mdb_result(ffi::mdb_drop(txn.txn.txn_ptr().as_mut(), self.dbi, 0)).map_err(Into::into)
         }
     }
 

--- a/heed/src/databases/database.rs
+++ b/heed/src/databases/database.rs
@@ -172,13 +172,13 @@ impl<'e, 'n, T, KC, DC, C> DatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
     }
 }
 
-impl<T, KC, DC, C> Clone for DatabaseOpenOptions<'_, '_, T, KC, DC, C> {
+impl<KC, DC, C> Clone for DatabaseOpenOptions<'_, '_, KC, DC, C> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<T, KC, DC, C> Copy for DatabaseOpenOptions<'_, '_, T, KC, DC, C> {}
+impl<KC, DC, C> Copy for DatabaseOpenOptions<'_, '_, KC, DC, C> {}
 
 /// A typed database that accepts only the types it was created with.
 ///
@@ -433,7 +433,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
         &self,
         txn: &'txn RoTxn<T>,
         key: &'a KC::EItem,
-    ) -> Result<Option<RoIter<'txn, T, KC, DC, MoveOnCurrentKeyDuplicates>>>
+    ) -> Result<Option<RoIter<'txn, KC, DC, MoveOnCurrentKeyDuplicates>>>
     where
         KC: BytesEncode<'a>,
     {
@@ -1026,7 +1026,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn iter<'txn, T>(&self, txn: &'txn RoTxn<T>) -> Result<RoIter<'txn, T, KC, DC>> {
+    pub fn iter<'txn, T>(&self, txn: &'txn RoTxn<T>) -> Result<RoIter<'txn, KC, DC>> {
         assert_eq_env_db_txn!(self, txn);
         RoCursor::new(txn, self.dbi).map(|cursor| RoIter::new(cursor))
     }
@@ -1128,7 +1128,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_iter<'txn, T>(&self, txn: &'txn RoTxn<T>) -> Result<RoRevIter<'txn, T, KC, DC>> {
+    pub fn rev_iter<'txn, T>(&self, txn: &'txn RoTxn<T>) -> Result<RoRevIter<'txn, KC, DC>> {
         assert_eq_env_db_txn!(self, txn);
 
         RoCursor::new(txn, self.dbi).map(|cursor| RoRevIter::new(cursor))
@@ -1239,7 +1239,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
         &self,
         txn: &'txn RoTxn<T>,
         range: &'a R,
-    ) -> Result<RoRange<'txn, T, KC, DC, C>>
+    ) -> Result<RoRange<'txn, KC, DC, C>>
     where
         KC: BytesEncode<'a>,
         R: RangeBounds<KC::EItem>,
@@ -1412,7 +1412,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
         &self,
         txn: &'txn RoTxn<T>,
         range: &'a R,
-    ) -> Result<RoRevRange<'txn, T, KC, DC, C>>
+    ) -> Result<RoRevRange<'txn, KC, DC, C>>
     where
         KC: BytesEncode<'a>,
         R: RangeBounds<KC::EItem>,
@@ -1587,7 +1587,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
         &self,
         txn: &'txn RoTxn<T>,
         prefix: &'a KC::EItem,
-    ) -> Result<RoPrefix<'txn, T, KC, DC, C>>
+    ) -> Result<RoPrefix<'txn, KC, DC, C>>
     where
         KC: BytesEncode<'a>,
         C: LexicographicComparator,
@@ -1720,7 +1720,7 @@ impl<KC, DC, C> Database<KC, DC, C> {
         &self,
         txn: &'txn RoTxn<'_, T>,
         prefix: &'a KC::EItem,
-    ) -> Result<RoRevPrefix<'txn, T, KC, DC, C>>
+    ) -> Result<RoRevPrefix<'txn, KC, DC, C>>
     where
         KC: BytesEncode<'a>,
         C: LexicographicComparator,

--- a/heed/src/databases/encrypted_database.rs
+++ b/heed/src/databases/encrypted_database.rs
@@ -53,8 +53,8 @@ use crate::*;
 /// # Ok(()) }
 /// ```
 #[derive(Debug)]
-pub struct EncryptedDatabaseOpenOptions<'e, 'n, KC, DC, C = DefaultComparator> {
-    inner: DatabaseOpenOptions<'e, 'n, KC, DC, C>,
+pub struct EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C = DefaultComparator> {
+    inner: DatabaseOpenOptions<'e, 'n, T, KC, DC, C>,
 }
 
 impl<'e, T> EncryptedDatabaseOpenOptions<'e, 'static, T, Unspecified, Unspecified> {
@@ -64,7 +64,7 @@ impl<'e, T> EncryptedDatabaseOpenOptions<'e, 'static, T, Unspecified, Unspecifie
     }
 }
 
-impl<'e, 'n, KC, DC, C> EncryptedDatabaseOpenOptions<'e, 'n, KC, DC, C> {
+impl<'e, 'n, T, KC, DC, C> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
     /// Change the type of the database.
     ///
     /// The default types are [`Unspecified`] and require a call to [`Database::remap_types`]
@@ -75,7 +75,7 @@ impl<'e, 'n, KC, DC, C> EncryptedDatabaseOpenOptions<'e, 'n, KC, DC, C> {
     /// Change the customized key compare function of the database.
     ///
     /// By default no customized compare function will be set when opening a database.
-    pub fn key_comparator<NC>(self) -> EncryptedDatabaseOpenOptions<'e, 'n, KC, DC, NC> {
+    pub fn key_comparator<NC>(self) -> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, NC> {
         EncryptedDatabaseOpenOptions { inner: self.inner.key_comparator() }
     }
 

--- a/heed/src/databases/encrypted_database.rs
+++ b/heed/src/databases/encrypted_database.rs
@@ -53,8 +53,8 @@ use crate::*;
 /// # Ok(()) }
 /// ```
 #[derive(Debug)]
-pub struct EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C = DefaultComparator> {
-    inner: DatabaseOpenOptions<'e, 'n, T, KC, DC, C>,
+pub struct EncryptedDatabaseOpenOptions<'e, 'n, KC, DC, C = DefaultComparator> {
+    inner: DatabaseOpenOptions<'e, 'n, KC, DC, C>,
 }
 
 impl<'e, T> EncryptedDatabaseOpenOptions<'e, 'static, T, Unspecified, Unspecified> {
@@ -64,7 +64,7 @@ impl<'e, T> EncryptedDatabaseOpenOptions<'e, 'static, T, Unspecified, Unspecifie
     }
 }
 
-impl<'e, 'n, T, KC, DC, C> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
+impl<'e, 'n, KC, DC, C> EncryptedDatabaseOpenOptions<'e, 'n, KC, DC, C> {
     /// Change the type of the database.
     ///
     /// The default types are [`Unspecified`] and require a call to [`Database::remap_types`]
@@ -75,7 +75,7 @@ impl<'e, 'n, T, KC, DC, C> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
     /// Change the customized key compare function of the database.
     ///
     /// By default no customized compare function will be set when opening a database.
-    pub fn key_comparator<NC>(self) -> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, NC> {
+    pub fn key_comparator<NC>(self) -> EncryptedDatabaseOpenOptions<'e, 'n, KC, DC, NC> {
         EncryptedDatabaseOpenOptions { inner: self.inner.key_comparator() }
     }
 
@@ -139,13 +139,13 @@ impl<'e, 'n, T, KC, DC, C> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
     }
 }
 
-impl<T, KC, DC, C> Clone for EncryptedDatabaseOpenOptions<'_, '_, T, KC, DC, C> {
+impl<KC, DC, C> Clone for EncryptedDatabaseOpenOptions<'_, '_, KC, DC, C> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<T, KC, DC, C> Copy for EncryptedDatabaseOpenOptions<'_, '_, T, KC, DC, C> {}
+impl<KC, DC, C> Copy for EncryptedDatabaseOpenOptions<'_, '_, KC, DC, C> {}
 
 /// A typed database that accepts only the types it was created with.
 ///
@@ -374,7 +374,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
         &self,
         txn: &'txn mut RoTxn<T>,
         key: &'a KC::EItem,
-    ) -> Result<Option<RoIter<'txn, T, KC, DC, MoveOnCurrentKeyDuplicates>>>
+    ) -> Result<Option<RoIter<'txn, KC, DC, MoveOnCurrentKeyDuplicates>>>
     where
         KC: BytesEncode<'a>,
     {
@@ -862,7 +862,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn iter<'txn, T>(&self, txn: &'txn mut RoTxn<T>) -> Result<RoIter<'txn, T, KC, DC>> {
+    pub fn iter<'txn, T>(&self, txn: &'txn mut RoTxn<T>) -> Result<RoIter<'txn, KC, DC>> {
         self.inner.iter(txn)
     }
 
@@ -961,7 +961,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_iter<'txn, T>(&self, txn: &'txn mut RoTxn<T>) -> Result<RoRevIter<'txn, T, KC, DC>> {
+    pub fn rev_iter<'txn, T>(&self, txn: &'txn mut RoTxn<T>) -> Result<RoRevIter<'txn, KC, DC>> {
         self.inner.rev_iter(txn)
     }
 
@@ -1068,7 +1068,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
         &self,
         txn: &'txn mut RoTxn<T>,
         range: &'a R,
-    ) -> Result<RoRange<'txn, T, KC, DC, C>>
+    ) -> Result<RoRange<'txn, KC, DC, C>>
     where
         KC: BytesEncode<'a>,
         R: RangeBounds<KC::EItem>,
@@ -1191,7 +1191,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
         &self,
         txn: &'txn mut RoTxn<T>,
         range: &'a R,
-    ) -> Result<RoRevRange<'txn, T, KC, DC, C>>
+    ) -> Result<RoRevRange<'txn, KC, DC, C>>
     where
         KC: BytesEncode<'a>,
         R: RangeBounds<KC::EItem>,
@@ -1315,7 +1315,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
         &self,
         txn: &'txn mut RoTxn<T>,
         prefix: &'a KC::EItem,
-    ) -> Result<RoPrefix<'txn, T, KC, DC, C>>
+    ) -> Result<RoPrefix<'txn, KC, DC, C>>
     where
         KC: BytesEncode<'a>,
         C: LexicographicComparator,
@@ -1440,7 +1440,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
         &self,
         txn: &'txn mut RoTxn<T>,
         prefix: &'a KC::EItem,
-    ) -> Result<RoRevPrefix<'txn, T, KC, DC, C>>
+    ) -> Result<RoRevPrefix<'txn, KC, DC, C>>
     where
         KC: BytesEncode<'a>,
         C: LexicographicComparator,

--- a/heed/src/databases/encrypted_database.rs
+++ b/heed/src/databases/encrypted_database.rs
@@ -111,7 +111,7 @@ impl<'e, 'n, T, KC, DC, C> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
     ///
     /// If not done, you might raise `Io(Os { code: 22, kind: InvalidInput, message: "Invalid argument" })`
     /// known as `EINVAL`.
-    pub fn open(&self, rtxn: &RoTxn<T>) -> Result<Option<EncryptedDatabase<KC, DC, C>>>
+    pub fn open(&self, rtxn: &RoTxn) -> Result<Option<EncryptedDatabase<KC, DC, C>>>
     where
         KC: 'static,
         DC: 'static,
@@ -139,13 +139,13 @@ impl<'e, 'n, T, KC, DC, C> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
     }
 }
 
-impl<KC, DC, C> Clone for EncryptedDatabaseOpenOptions<'_, '_, KC, DC, C> {
+impl<T, KC, DC, C> Clone for EncryptedDatabaseOpenOptions<'_, '_, T, KC, DC, C> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<KC, DC, C> Copy for EncryptedDatabaseOpenOptions<'_, '_, KC, DC, C> {}
+impl<T, KC, DC, C> Copy for EncryptedDatabaseOpenOptions<'_, '_, T, KC, DC, C> {}
 
 /// A typed database that accepts only the types it was created with.
 ///
@@ -305,9 +305,9 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get<'a, 'txn, T>(
+    pub fn get<'a, 'txn>(
         &self,
-        txn: &'txn mut RoTxn<T>,
+        txn: &'txn mut RoTxn,
         key: &'a KC::EItem,
     ) -> Result<Option<DC::DItem>>
     where
@@ -370,9 +370,9 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_duplicates<'a, 'txn, T>(
+    pub fn get_duplicates<'a, 'txn>(
         &self,
-        txn: &'txn mut RoTxn<T>,
+        txn: &'txn mut RoTxn,
         key: &'a KC::EItem,
     ) -> Result<Option<RoIter<'txn, KC, DC, MoveOnCurrentKeyDuplicates>>>
     where
@@ -425,9 +425,9 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_lower_than<'a, 'txn, T>(
+    pub fn get_lower_than<'a, 'txn>(
         &self,
-        txn: &'txn mut RoTxn<T>,
+        txn: &'txn mut RoTxn,
         key: &'a KC::EItem,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
@@ -481,9 +481,9 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_lower_than_or_equal_to<'a, 'txn, T>(
+    pub fn get_lower_than_or_equal_to<'a, 'txn>(
         &self,
-        txn: &'txn mut RoTxn<T>,
+        txn: &'txn mut RoTxn,
         key: &'a KC::EItem,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
@@ -537,9 +537,9 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_greater_than<'a, 'txn, T>(
+    pub fn get_greater_than<'a, 'txn>(
         &self,
-        txn: &'txn mut RoTxn<T>,
+        txn: &'txn mut RoTxn,
         key: &'a KC::EItem,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
@@ -593,9 +593,9 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn get_greater_than_or_equal_to<'a, 'txn, T>(
+    pub fn get_greater_than_or_equal_to<'a, 'txn>(
         &self,
-        txn: &'txn mut RoTxn<T>,
+        txn: &'txn mut RoTxn,
         key: &'a KC::EItem,
     ) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
@@ -641,7 +641,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn first<'txn, T>(&self, txn: &'txn mut RoTxn<T>) -> Result<Option<(KC::DItem, DC::DItem)>>
+    pub fn first<'txn>(&self, txn: &'txn mut RoTxn) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
         KC: BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
@@ -685,7 +685,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn last<'txn, T>(&self, txn: &'txn mut RoTxn<T>) -> Result<Option<(KC::DItem, DC::DItem)>>
+    pub fn last<'txn>(&self, txn: &'txn mut RoTxn) -> Result<Option<(KC::DItem, DC::DItem)>>
     where
         KC: BytesDecode<'txn>,
         DC: BytesDecode<'txn>,
@@ -732,7 +732,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn len<T>(&self, txn: &RoTxn<T>) -> Result<u64> {
+    pub fn len(&self, txn: &RoTxn) -> Result<u64> {
         self.inner.len(txn)
     }
 
@@ -775,7 +775,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn is_empty<T>(&self, txn: &RoTxn<T>) -> Result<bool> {
+    pub fn is_empty(&self, txn: &RoTxn) -> Result<bool> {
         self.inner.is_empty(txn)
     }
 
@@ -817,7 +817,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn stat<T>(&self, txn: &RoTxn<T>) -> Result<DatabaseStat> {
+    pub fn stat(&self, txn: &RoTxn) -> Result<DatabaseStat> {
         self.inner.stat(txn)
     }
 
@@ -862,7 +862,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn iter<'txn, T>(&self, txn: &'txn mut RoTxn<T>) -> Result<RoIter<'txn, KC, DC>> {
+    pub fn iter<'txn>(&self, txn: &'txn mut RoTxn) -> Result<RoIter<'txn, KC, DC>> {
         self.inner.iter(txn)
     }
 
@@ -961,7 +961,7 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_iter<'txn, T>(&self, txn: &'txn mut RoTxn<T>) -> Result<RoRevIter<'txn, KC, DC>> {
+    pub fn rev_iter<'txn>(&self, txn: &'txn mut RoTxn) -> Result<RoRevIter<'txn, KC, DC>> {
         self.inner.rev_iter(txn)
     }
 
@@ -1064,9 +1064,9 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn range<'a, 'txn, R, T>(
+    pub fn range<'a, 'txn, R>(
         &self,
-        txn: &'txn mut RoTxn<T>,
+        txn: &'txn mut RoTxn,
         range: &'a R,
     ) -> Result<RoRange<'txn, KC, DC, C>>
     where
@@ -1187,9 +1187,9 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_range<'a, 'txn, R, T>(
+    pub fn rev_range<'a, 'txn, R>(
         &self,
-        txn: &'txn mut RoTxn<T>,
+        txn: &'txn mut RoTxn,
         range: &'a R,
     ) -> Result<RoRevRange<'txn, KC, DC, C>>
     where
@@ -1311,9 +1311,9 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn prefix_iter<'a, 'txn, T>(
+    pub fn prefix_iter<'a, 'txn>(
         &self,
-        txn: &'txn mut RoTxn<T>,
+        txn: &'txn mut RoTxn,
         prefix: &'a KC::EItem,
     ) -> Result<RoPrefix<'txn, KC, DC, C>>
     where
@@ -1436,9 +1436,9 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn rev_prefix_iter<'a, 'txn, T>(
+    pub fn rev_prefix_iter<'a, 'txn>(
         &self,
-        txn: &'txn mut RoTxn<T>,
+        txn: &'txn mut RoTxn,
         prefix: &'a KC::EItem,
     ) -> Result<RoRevPrefix<'txn, KC, DC, C>>
     where

--- a/heed/src/envs/encrypted_env.rs
+++ b/heed/src/envs/encrypted_env.rs
@@ -127,7 +127,7 @@ impl<T> EncryptedEnv<T> {
     /// known as `EINVAL`.
     pub fn open_database<KC, DC>(
         &self,
-        rtxn: &RoTxn<T>,
+        rtxn: &RoTxn,
         name: Option<&str>,
     ) -> Result<Option<EncryptedDatabase<KC, DC>>>
     where

--- a/heed/src/envs/env.rs
+++ b/heed/src/envs/env.rs
@@ -218,7 +218,7 @@ impl<T> Env<T> {
     /// known as `EINVAL`.
     pub fn open_database<KC, DC>(
         &self,
-        rtxn: &RoTxn<T>,
+        rtxn: &RoTxn,
         name: Option<&str>,
     ) -> Result<Option<Database<KC, DC>>>
     where

--- a/heed/src/envs/env.rs
+++ b/heed/src/envs/env.rs
@@ -22,12 +22,14 @@ use crate::mdb::lmdb_flags::AllDatabaseFlags;
 use crate::EnvOpenOptions;
 use crate::{
     CompactionOption, Database, DatabaseOpenOptions, EnvFlags, Error, Result, RoTxn, RwTxn,
-    Unspecified, WithoutTls,
+    Unspecified,
 };
 
 /// An environment handle constructed by using [`EnvOpenOptions::open`].
+#[repr(transparent)]
 pub struct Env<T> {
-    inner: Arc<EnvInner<T>>,
+    pub(crate) inner: Arc<EnvInner>,
+    _tls_marker: PhantomData<T>,
 }
 
 impl<T> Env<T> {
@@ -36,21 +38,11 @@ impl<T> Env<T> {
         path: PathBuf,
         signal_event: Arc<SignalEvent>,
     ) -> Self {
-        Env { inner: Arc::new(EnvInner { env_ptr, path, signal_event, _tls_marker: PhantomData }) }
+        Env { inner: Arc::new(EnvInner { env_ptr, path, signal_event }), _tls_marker: PhantomData }
     }
 
     pub(crate) fn env_mut_ptr(&self) -> NonNull<ffi::MDB_env> {
-        self.inner.env_ptr
-    }
-
-    /// Converts any `Env` into `Env<WithoutTls>`, useful for wrapping
-    /// into a `RwTxn` due to the latter always being `WithoutTls`.
-    ///
-    /// # Safety
-    ///
-    /// Do not use this `Env` to create transactions but only keep it.
-    pub(crate) unsafe fn as_without_tls(&self) -> &Env<WithoutTls> {
-        unsafe { std::mem::transmute::<&Env<T>, &Env<WithoutTls>>(self) }
+        self.inner.env_mut_ptr()
     }
 
     /// The size of the data file on disk.
@@ -175,7 +167,7 @@ impl<T> Env<T> {
 
         let rtxn = self.read_txn()?;
         // Open the main database
-        let dbi = self.raw_open_dbi::<DefaultComparator>(rtxn.txn.unwrap(), None, 0)?;
+        let dbi = self.raw_open_dbi::<DefaultComparator>(rtxn.txn_ptr(), None, 0)?;
 
         // We're going to iterate on the unnamed database
         let mut cursor = RoCursor::new(&rtxn, dbi)?;
@@ -188,12 +180,10 @@ impl<T> Env<T> {
             let key = String::from_utf8(key.to_vec()).unwrap();
             // Calling `ffi::db_stat` on a database instance does not involve key comparison
             // in LMDB, so it's safe to specify a noop key compare function for it.
-            if let Ok(dbi) =
-                self.raw_open_dbi::<DefaultComparator>(rtxn.txn.unwrap(), Some(&key), 0)
-            {
+            if let Ok(dbi) = self.raw_open_dbi::<DefaultComparator>(rtxn.txn_ptr(), Some(&key), 0) {
                 let mut stat = mem::MaybeUninit::uninit();
                 unsafe {
-                    mdb_result(ffi::mdb_stat(rtxn.txn.unwrap().as_mut(), dbi, stat.as_mut_ptr()))?
+                    mdb_result(ffi::mdb_stat(rtxn.txn_ptr().as_mut(), dbi, stat.as_mut_ptr()))?
                 };
                 let stat = unsafe { stat.assume_init() };
                 size += compute_size(stat);
@@ -531,7 +521,7 @@ impl<T> Env<T> {
 
 impl<T> Clone for Env<T> {
     fn clone(&self) -> Self {
-        Env { inner: self.inner.clone() }
+        Env { inner: self.inner.clone(), _tls_marker: PhantomData }
     }
 }
 
@@ -544,17 +534,22 @@ impl<T> fmt::Debug for Env<T> {
     }
 }
 
-pub(crate) struct EnvInner<T> {
+pub(crate) struct EnvInner {
     env_ptr: NonNull<MDB_env>,
     signal_event: Arc<SignalEvent>,
     pub(crate) path: PathBuf,
-    _tls_marker: PhantomData<T>,
 }
 
-unsafe impl<T> Send for EnvInner<T> {}
-unsafe impl<T> Sync for EnvInner<T> {}
+impl EnvInner {
+    pub(crate) fn env_mut_ptr(&self) -> NonNull<ffi::MDB_env> {
+        self.env_ptr
+    }
+}
 
-impl<T> Drop for EnvInner<T> {
+unsafe impl Send for EnvInner {}
+unsafe impl Sync for EnvInner {}
+
+impl Drop for EnvInner {
     fn drop(&mut self) {
         let mut lock = OPENED_ENV.write().unwrap();
         let removed = lock.remove(&self.path);

--- a/heed/src/envs/mod.rs
+++ b/heed/src/envs/mod.rs
@@ -31,6 +31,7 @@ mod env_open_options;
 #[cfg(master3)]
 pub use encrypted_env::EncryptedEnv;
 pub use env::Env;
+pub(crate) use env::EnvInner;
 pub use env_open_options::EnvOpenOptions;
 
 /// Records the current list of opened environments for tracking purposes. The canonical

--- a/heed/src/iterator/iter.rs
+++ b/heed/src/iterator/iter.rs
@@ -7,14 +7,14 @@ use crate::iteration_method::{IterationMethod, MoveBetweenKeys, MoveThroughDupli
 use crate::*;
 
 /// A read-only iterator structure.
-pub struct RoIter<'txn, T, KC, DC, IM = MoveThroughDuplicateValues> {
-    cursor: RoCursor<'txn, T>,
+pub struct RoIter<'txn, KC, DC, IM = MoveThroughDuplicateValues> {
+    cursor: RoCursor<'txn>,
     move_on_first: bool,
     _phantom: marker::PhantomData<(KC, DC, IM)>,
 }
 
-impl<'txn, T, KC, DC, IM> RoIter<'txn, T, KC, DC, IM> {
-    pub(crate) fn new(cursor: RoCursor<'txn, T>) -> RoIter<'txn, T, KC, DC, IM> {
+impl<'txn, KC, DC, IM> RoIter<'txn, KC, DC, IM> {
+    pub(crate) fn new(cursor: RoCursor<'txn>) -> RoIter<'txn, KC, DC, IM> {
         RoIter { cursor, move_on_first: true, _phantom: marker::PhantomData }
     }
 
@@ -63,7 +63,7 @@ impl<'txn, T, KC, DC, IM> RoIter<'txn, T, KC, DC, IM> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn move_between_keys(self) -> RoIter<'txn, T, KC, DC, MoveBetweenKeys> {
+    pub fn move_between_keys(self) -> RoIter<'txn, KC, DC, MoveBetweenKeys> {
         RoIter {
             cursor: self.cursor,
             move_on_first: self.move_on_first,
@@ -119,9 +119,7 @@ impl<'txn, T, KC, DC, IM> RoIter<'txn, T, KC, DC, IM> {
     /// wtxn.commit()?;
     /// # Ok(()) }
     /// ```
-    pub fn move_through_duplicate_values(
-        self,
-    ) -> RoIter<'txn, T, KC, DC, MoveThroughDuplicateValues> {
+    pub fn move_through_duplicate_values(self) -> RoIter<'txn, KC, DC, MoveThroughDuplicateValues> {
         RoIter {
             cursor: self.cursor,
             move_on_first: self.move_on_first,
@@ -130,7 +128,7 @@ impl<'txn, T, KC, DC, IM> RoIter<'txn, T, KC, DC, IM> {
     }
 
     /// Change the codec types of this iterator, specifying the codecs.
-    pub fn remap_types<KC2, DC2>(self) -> RoIter<'txn, T, KC2, DC2, IM> {
+    pub fn remap_types<KC2, DC2>(self) -> RoIter<'txn, KC2, DC2, IM> {
         RoIter {
             cursor: self.cursor,
             move_on_first: self.move_on_first,
@@ -139,22 +137,22 @@ impl<'txn, T, KC, DC, IM> RoIter<'txn, T, KC, DC, IM> {
     }
 
     /// Change the key codec type of this iterator, specifying the new codec.
-    pub fn remap_key_type<KC2>(self) -> RoIter<'txn, T, KC2, DC, IM> {
+    pub fn remap_key_type<KC2>(self) -> RoIter<'txn, KC2, DC, IM> {
         self.remap_types::<KC2, DC>()
     }
 
     /// Change the data codec type of this iterator, specifying the new codec.
-    pub fn remap_data_type<DC2>(self) -> RoIter<'txn, T, KC, DC2, IM> {
+    pub fn remap_data_type<DC2>(self) -> RoIter<'txn, KC, DC2, IM> {
         self.remap_types::<KC, DC2>()
     }
 
     /// Wrap the data bytes into a lazy decoder.
-    pub fn lazily_decode_data(self) -> RoIter<'txn, T, KC, LazyDecode<DC>, IM> {
+    pub fn lazily_decode_data(self) -> RoIter<'txn, KC, LazyDecode<DC>, IM> {
         self.remap_types::<KC, LazyDecode<DC>>()
     }
 }
 
-impl<'txn, T, KC, DC, IM> Iterator for RoIter<'txn, T, KC, DC, IM>
+impl<'txn, KC, DC, IM> Iterator for RoIter<'txn, KC, DC, IM>
 where
     KC: BytesDecode<'txn>,
     DC: BytesDecode<'txn>,
@@ -204,14 +202,14 @@ where
     }
 }
 
-impl<T, KC, DC, IM> fmt::Debug for RoIter<'_, T, KC, DC, IM> {
+impl<KC, DC, IM> fmt::Debug for RoIter<'_, KC, DC, IM> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RoIter").finish()
     }
 }
 
 /// A `RoIter` is `Send` only if the `RoTxn` is.
-unsafe impl<KC, DC, IM> Send for RoIter<'_, WithoutTls, KC, DC, IM> {}
+unsafe impl<KC, DC, IM> Send for RoIter<'_, KC, DC, IM> {}
 
 /// A read-write iterator structure.
 pub struct RwIter<'txn, KC, DC, IM = MoveThroughDuplicateValues> {
@@ -443,21 +441,21 @@ impl<KC, DC, IM> fmt::Debug for RwIter<'_, KC, DC, IM> {
 }
 
 /// A reverse read-only iterator structure.
-pub struct RoRevIter<'txn, T, KC, DC, IM = MoveThroughDuplicateValues> {
-    cursor: RoCursor<'txn, T>,
+pub struct RoRevIter<'txn, KC, DC, IM = MoveThroughDuplicateValues> {
+    cursor: RoCursor<'txn>,
     move_on_last: bool,
     _phantom: marker::PhantomData<(KC, DC, IM)>,
 }
 
-impl<'txn, T, KC, DC, IM> RoRevIter<'txn, T, KC, DC, IM> {
-    pub(crate) fn new(cursor: RoCursor<'txn, T>) -> RoRevIter<'txn, T, KC, DC, IM> {
+impl<'txn, KC, DC, IM> RoRevIter<'txn, KC, DC, IM> {
+    pub(crate) fn new(cursor: RoCursor<'txn>) -> RoRevIter<'txn, KC, DC, IM> {
         RoRevIter { cursor, move_on_last: true, _phantom: marker::PhantomData }
     }
 
     /// Move on the first value of keys, ignoring duplicate values.
     ///
     /// For more info, see [`RoIter::move_between_keys`].
-    pub fn move_between_keys(self) -> RoRevIter<'txn, T, KC, DC, MoveBetweenKeys> {
+    pub fn move_between_keys(self) -> RoRevIter<'txn, KC, DC, MoveBetweenKeys> {
         RoRevIter {
             cursor: self.cursor,
             move_on_last: self.move_on_last,
@@ -470,7 +468,7 @@ impl<'txn, T, KC, DC, IM> RoRevIter<'txn, T, KC, DC, IM> {
     /// For more info, see [`RoIter::move_through_duplicate_values`].
     pub fn move_through_duplicate_values(
         self,
-    ) -> RoRevIter<'txn, T, KC, DC, MoveThroughDuplicateValues> {
+    ) -> RoRevIter<'txn, KC, DC, MoveThroughDuplicateValues> {
         RoRevIter {
             cursor: self.cursor,
             move_on_last: self.move_on_last,
@@ -479,7 +477,7 @@ impl<'txn, T, KC, DC, IM> RoRevIter<'txn, T, KC, DC, IM> {
     }
 
     /// Change the codec types of this iterator, specifying the codecs.
-    pub fn remap_types<KC2, DC2>(self) -> RoRevIter<'txn, T, KC2, DC2, IM> {
+    pub fn remap_types<KC2, DC2>(self) -> RoRevIter<'txn, KC2, DC2, IM> {
         RoRevIter {
             cursor: self.cursor,
             move_on_last: self.move_on_last,
@@ -488,22 +486,22 @@ impl<'txn, T, KC, DC, IM> RoRevIter<'txn, T, KC, DC, IM> {
     }
 
     /// Change the key codec type of this iterator, specifying the new codec.
-    pub fn remap_key_type<KC2>(self) -> RoRevIter<'txn, T, KC2, DC, IM> {
+    pub fn remap_key_type<KC2>(self) -> RoRevIter<'txn, KC2, DC, IM> {
         self.remap_types::<KC2, DC>()
     }
 
     /// Change the data codec type of this iterator, specifying the new codec.
-    pub fn remap_data_type<DC2>(self) -> RoRevIter<'txn, T, KC, DC2, IM> {
+    pub fn remap_data_type<DC2>(self) -> RoRevIter<'txn, KC, DC2, IM> {
         self.remap_types::<KC, DC2>()
     }
 
     /// Wrap the data bytes into a lazy decoder.
-    pub fn lazily_decode_data(self) -> RoRevIter<'txn, T, KC, LazyDecode<DC>, IM> {
+    pub fn lazily_decode_data(self) -> RoRevIter<'txn, KC, LazyDecode<DC>, IM> {
         self.remap_types::<KC, LazyDecode<DC>>()
     }
 }
 
-impl<'txn, T, KC, DC, IM> Iterator for RoRevIter<'txn, T, KC, DC, IM>
+impl<'txn, KC, DC, IM> Iterator for RoRevIter<'txn, KC, DC, IM>
 where
     KC: BytesDecode<'txn>,
     DC: BytesDecode<'txn>,
@@ -559,7 +557,7 @@ impl<KC, DC, IM> fmt::Debug for RoRevIter<'_, KC, DC, IM> {
     }
 }
 
-unsafe impl<KC, DC, IM> Send for RoRevIter<'_, WithoutTls, KC, DC, IM> {}
+unsafe impl<KC, DC, IM> Send for RoRevIter<'_, KC, DC, IM> {}
 
 /// A reverse read-write iterator structure.
 pub struct RwRevIter<'txn, KC, DC, IM = MoveThroughDuplicateValues> {

--- a/heed/src/iterator/iter.rs
+++ b/heed/src/iterator/iter.rs
@@ -208,9 +208,6 @@ impl<KC, DC, IM> fmt::Debug for RoIter<'_, KC, DC, IM> {
     }
 }
 
-/// A `RoIter` is `Send` only if the `RoTxn` is.
-unsafe impl<KC, DC, IM> Send for RoIter<'_, KC, DC, IM> {}
-
 /// A read-write iterator structure.
 pub struct RwIter<'txn, KC, DC, IM = MoveThroughDuplicateValues> {
     cursor: RwCursor<'txn>,
@@ -556,8 +553,6 @@ impl<KC, DC, IM> fmt::Debug for RoRevIter<'_, KC, DC, IM> {
         f.debug_struct("RoRevIter").finish()
     }
 }
-
-unsafe impl<KC, DC, IM> Send for RoRevIter<'_, KC, DC, IM> {}
 
 /// A reverse read-write iterator structure.
 pub struct RwRevIter<'txn, KC, DC, IM = MoveThroughDuplicateValues> {

--- a/heed/src/iterator/mod.rs
+++ b/heed/src/iterator/mod.rs
@@ -6,6 +6,99 @@ pub use self::iter::{RoIter, RoRevIter, RwIter, RwRevIter};
 pub use self::prefix::{RoPrefix, RoRevPrefix, RwPrefix, RwRevPrefix};
 pub use self::range::{RoRange, RoRevRange, RwRange, RwRevRange};
 
+/// This is just set of tests to check that the Cursors
+/// are not Send. We need to use doc test as it is the
+/// only way to check for expected compilation failures.
+///
+/// ```rust,compile_fail
+/// use heed::types::*;
+/// use heed::RoIter;
+/// fn is_send<T: Send>() {}
+/// is_send::<RoIter<Bytes, Bytes>>();
+/// ```
+///
+/// ```rust,compile_fail
+/// use heed::types::*;
+/// use heed::RoRevIter;
+/// fn is_send<T: Send>() {}
+/// is_send::<RoRevIter<Bytes, Bytes>>();
+/// ```
+///
+/// ```rust,compile_fail
+/// use heed::types::*;
+/// use heed::RoRange;
+/// fn is_send<T: Send>() {}
+/// is_send::<RoRange<Bytes, Bytes>>();
+/// ```
+///
+/// ```rust,compile_fail
+/// use heed::types::*;
+/// use heed::RoRevRange;
+/// fn is_send<T: Send>() {}
+/// is_send::<RoRevRange<Bytes, Bytes>>();
+/// ```
+///
+/// ```rust,compile_fail
+/// use heed::types::*;
+/// use heed::RoPrefix;
+/// fn is_send<T: Send>() {}
+/// is_send::<RoPrefix<Bytes, Bytes>>();
+/// ```
+///
+/// ```rust,compile_fail
+/// use heed::types::*;
+/// use heed::RoRevPrefix;
+/// fn is_send<T: Send>() {}
+/// is_send::<RoRevPrefix<Bytes, Bytes>>();
+/// ```
+///
+/// Starting the next section with the Read-write Iterators.
+///
+/// ```rust,compile_fail
+/// use heed::types::*;
+/// use heed::RwIter;
+/// fn is_send<T: Send>() {}
+/// is_send::<RwIter<Bytes, Bytes>>();
+/// ```
+///
+/// ```rust,compile_fail
+/// use heed::types::*;
+/// use heed::RwRevIter;
+/// fn is_send<T: Send>() {}
+/// is_send::<RwRevIter<Bytes, Bytes>>();
+/// ```
+///
+/// ```rust,compile_fail
+/// use heed::types::*;
+/// use heed::RwRange;
+/// fn is_send<T: Send>() {}
+/// is_send::<RwRange<Bytes, Bytes>>();
+/// ```
+///
+/// ```rust,compile_fail
+/// use heed::types::*;
+/// use heed::RwRevRange;
+/// fn is_send<T: Send>() {}
+/// is_send::<RwRevRange<Bytes, Bytes>>();
+/// ```
+///
+/// ```rust,compile_fail
+/// use heed::types::*;
+/// use heed::RwPrefix;
+/// fn is_send<T: Send>() {}
+/// is_send::<RwPrefix<Bytes, Bytes>>();
+/// ```
+///
+/// ```rust,compile_fail
+/// use heed::types::*;
+/// use heed::RwRevPrefix;
+/// fn is_send<T: Send>() {}
+/// is_send::<RwRevPrefix<Bytes, Bytes>>();
+/// ```
+#[doc(hidden)]
+#[allow(unused)]
+fn test_txns_are_not_send() {}
+
 #[cfg(test)]
 mod tests {
     use std::ops;

--- a/heed/src/iterator/prefix.rs
+++ b/heed/src/iterator/prefix.rs
@@ -200,8 +200,6 @@ impl<KC, DC, C, IM> fmt::Debug for RoPrefix<'_, KC, DC, C, IM> {
     }
 }
 
-unsafe impl<KC, DC, IM> Send for RoPrefix<'_, WithoutTls, KC, DC, IM> {}
-
 /// A read-write prefix iterator structure.
 pub struct RwPrefix<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {
     cursor: RwCursor<'txn>,
@@ -588,8 +586,6 @@ impl<KC, DC, C, IM> fmt::Debug for RoRevPrefix<'_, KC, DC, C, IM> {
         f.debug_struct("RoRevPrefix").finish()
     }
 }
-
-unsafe impl<KC, DC, IM> Send for RoRevPrefix<'_, WithoutTls, KC, DC, IM> {}
 
 /// A reverse read-write prefix iterator structure.
 pub struct RwRevPrefix<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {

--- a/heed/src/iterator/range.rs
+++ b/heed/src/iterator/range.rs
@@ -199,8 +199,6 @@ impl<KC, DC, C, IM> fmt::Debug for RoRange<'_, KC, DC, C, IM> {
     }
 }
 
-unsafe impl<KC, DC, C, IM> Send for RoRange<'_, KC, DC, C, IM> {}
-
 /// A read-write range iterator structure.
 pub struct RwRange<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {
     cursor: RwCursor<'txn>,
@@ -636,8 +634,6 @@ impl<KC, DC, C, IM> fmt::Debug for RoRevRange<'_, KC, DC, C, IM> {
         f.debug_struct("RoRevRange").finish()
     }
 }
-
-unsafe impl<KC, DC, C, IM> Send for RoRevRange<'_, KC, DC, C, IM> {}
 
 /// A reverse read-write range iterator structure.
 pub struct RwRevRange<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {

--- a/heed/src/iterator/range.rs
+++ b/heed/src/iterator/range.rs
@@ -8,8 +8,8 @@ use crate::cursor::MoveOperation;
 use crate::iteration_method::{IterationMethod, MoveBetweenKeys, MoveThroughDuplicateValues};
 use crate::*;
 
-fn move_on_range_end<'txn, T>(
-    cursor: &mut RoCursor<'txn, T>,
+fn move_on_range_end<'txn>(
+    cursor: &mut RoCursor<'txn>,
     end_bound: &Bound<Vec<u8>>,
 ) -> Result<Option<(&'txn [u8], &'txn [u8])>> {
     match end_bound {
@@ -25,8 +25,8 @@ fn move_on_range_end<'txn, T>(
     }
 }
 
-fn move_on_range_start<'txn, T>(
-    cursor: &mut RoCursor<'txn, T>,
+fn move_on_range_start<'txn>(
+    cursor: &mut RoCursor<'txn>,
     start_bound: &mut Bound<Vec<u8>>,
 ) -> Result<Option<(&'txn [u8], &'txn [u8])>> {
     match start_bound {
@@ -40,20 +40,20 @@ fn move_on_range_start<'txn, T>(
 }
 
 /// A read-only range iterator structure.
-pub struct RoRange<'txn, T, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {
-    cursor: RoCursor<'txn, T>,
+pub struct RoRange<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {
+    cursor: RoCursor<'txn>,
     move_on_start: bool,
     start_bound: Bound<Vec<u8>>,
     end_bound: Bound<Vec<u8>>,
     _phantom: marker::PhantomData<(KC, DC, C, IM)>,
 }
 
-impl<'txn, T, KC, DC, C, IM> RoRange<'txn, T, KC, DC, C, IM> {
+impl<'txn, KC, DC, C, IM> RoRange<'txn, KC, DC, C, IM> {
     pub(crate) fn new(
-        cursor: RoCursor<'txn, T>,
+        cursor: RoCursor<'txn>,
         start_bound: Bound<Vec<u8>>,
         end_bound: Bound<Vec<u8>>,
-    ) -> RoRange<'txn, T, KC, DC, C, IM> {
+    ) -> RoRange<'txn, KC, DC, C, IM> {
         RoRange {
             cursor,
             move_on_start: true,
@@ -66,7 +66,7 @@ impl<'txn, T, KC, DC, C, IM> RoRange<'txn, T, KC, DC, C, IM> {
     /// Move on the first value of keys, ignoring duplicate values.
     ///
     /// For more info, see [`RoIter::move_between_keys`].
-    pub fn move_between_keys(self) -> RoRange<'txn, T, KC, DC, C, MoveBetweenKeys> {
+    pub fn move_between_keys(self) -> RoRange<'txn, KC, DC, C, MoveBetweenKeys> {
         RoRange {
             cursor: self.cursor,
             move_on_start: self.move_on_start,
@@ -81,7 +81,7 @@ impl<'txn, T, KC, DC, C, IM> RoRange<'txn, T, KC, DC, C, IM> {
     /// For more info, see [`RoIter::move_through_duplicate_values`].
     pub fn move_through_duplicate_values(
         self,
-    ) -> RoRange<'txn, T, KC, DC, C, MoveThroughDuplicateValues> {
+    ) -> RoRange<'txn, KC, DC, C, MoveThroughDuplicateValues> {
         RoRange {
             cursor: self.cursor,
             move_on_start: self.move_on_start,
@@ -92,7 +92,7 @@ impl<'txn, T, KC, DC, C, IM> RoRange<'txn, T, KC, DC, C, IM> {
     }
 
     /// Change the codec types of this iterator, specifying the codecs.
-    pub fn remap_types<KC2, DC2>(self) -> RoRange<'txn, T, KC2, DC2, C, IM> {
+    pub fn remap_types<KC2, DC2>(self) -> RoRange<'txn, KC2, DC2, C, IM> {
         RoRange {
             cursor: self.cursor,
             move_on_start: self.move_on_start,
@@ -103,22 +103,22 @@ impl<'txn, T, KC, DC, C, IM> RoRange<'txn, T, KC, DC, C, IM> {
     }
 
     /// Change the key codec type of this iterator, specifying the new codec.
-    pub fn remap_key_type<KC2>(self) -> RoRange<'txn, T, KC2, DC, C, IM> {
+    pub fn remap_key_type<KC2>(self) -> RoRange<'txn, KC2, DC, C, IM> {
         self.remap_types::<KC2, DC>()
     }
 
     /// Change the data codec type of this iterator, specifying the new codec.
-    pub fn remap_data_type<DC2>(self) -> RoRange<'txn, T, KC, DC2, C, IM> {
+    pub fn remap_data_type<DC2>(self) -> RoRange<'txn, KC, DC2, C, IM> {
         self.remap_types::<KC, DC2>()
     }
 
     /// Wrap the data bytes into a lazy decoder.
-    pub fn lazily_decode_data(self) -> RoRange<'txn, T, KC, LazyDecode<DC>, C, IM> {
+    pub fn lazily_decode_data(self) -> RoRange<'txn, KC, LazyDecode<DC>, C, IM> {
         self.remap_types::<KC, LazyDecode<DC>>()
     }
 }
 
-impl<'txn, T, KC, DC, C, IM> Iterator for RoRange<'txn, T, KC, DC, C, IM>
+impl<'txn, KC, DC, C, IM> Iterator for RoRange<'txn, KC, DC, C, IM>
 where
     KC: BytesDecode<'txn>,
     DC: BytesDecode<'txn>,
@@ -199,7 +199,7 @@ impl<KC, DC, C, IM> fmt::Debug for RoRange<'_, KC, DC, C, IM> {
     }
 }
 
-unsafe impl<KC, DC, C, IM> Send for RoRange<'_, WithoutTls, KC, DC, C, IM> {}
+unsafe impl<KC, DC, C, IM> Send for RoRange<'_, KC, DC, C, IM> {}
 
 /// A read-write range iterator structure.
 pub struct RwRange<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {
@@ -476,20 +476,20 @@ impl<KC, DC, C, IM> fmt::Debug for RwRange<'_, KC, DC, C, IM> {
 }
 
 /// A reverse read-only range iterator structure.
-pub struct RoRevRange<'txn, T, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {
-    cursor: RoCursor<'txn, T>,
+pub struct RoRevRange<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {
+    cursor: RoCursor<'txn>,
     move_on_end: bool,
     start_bound: Bound<Vec<u8>>,
     end_bound: Bound<Vec<u8>>,
     _phantom: marker::PhantomData<(KC, DC, C, IM)>,
 }
 
-impl<'txn, T, KC, DC, C, IM> RoRevRange<'txn, T, KC, DC, C, IM> {
+impl<'txn, KC, DC, C, IM> RoRevRange<'txn, KC, DC, C, IM> {
     pub(crate) fn new(
-        cursor: RoCursor<'txn, T>,
+        cursor: RoCursor<'txn>,
         start_bound: Bound<Vec<u8>>,
         end_bound: Bound<Vec<u8>>,
-    ) -> RoRevRange<'txn, T, KC, DC, C, IM> {
+    ) -> RoRevRange<'txn, KC, DC, C, IM> {
         RoRevRange {
             cursor,
             move_on_end: true,
@@ -502,7 +502,7 @@ impl<'txn, T, KC, DC, C, IM> RoRevRange<'txn, T, KC, DC, C, IM> {
     /// Move on the first value of keys, ignoring duplicate values.
     ///
     /// For more info, see [`RoIter::move_between_keys`].
-    pub fn move_between_keys(self) -> RoRevRange<'txn, T, KC, DC, C, MoveBetweenKeys> {
+    pub fn move_between_keys(self) -> RoRevRange<'txn, KC, DC, C, MoveBetweenKeys> {
         RoRevRange {
             cursor: self.cursor,
             move_on_end: self.move_on_end,
@@ -517,7 +517,7 @@ impl<'txn, T, KC, DC, C, IM> RoRevRange<'txn, T, KC, DC, C, IM> {
     /// For more info, see [`RoIter::move_through_duplicate_values`].
     pub fn move_through_duplicate_values(
         self,
-    ) -> RoRevRange<'txn, T, KC, DC, C, MoveThroughDuplicateValues> {
+    ) -> RoRevRange<'txn, KC, DC, C, MoveThroughDuplicateValues> {
         RoRevRange {
             cursor: self.cursor,
             move_on_end: self.move_on_end,
@@ -528,7 +528,7 @@ impl<'txn, T, KC, DC, C, IM> RoRevRange<'txn, T, KC, DC, C, IM> {
     }
 
     /// Change the codec types of this iterator, specifying the codecs.
-    pub fn remap_types<KC2, DC2>(self) -> RoRevRange<'txn, T, KC2, DC2, C, IM> {
+    pub fn remap_types<KC2, DC2>(self) -> RoRevRange<'txn, KC2, DC2, C, IM> {
         RoRevRange {
             cursor: self.cursor,
             move_on_end: self.move_on_end,
@@ -539,22 +539,22 @@ impl<'txn, T, KC, DC, C, IM> RoRevRange<'txn, T, KC, DC, C, IM> {
     }
 
     /// Change the key codec type of this iterator, specifying the new codec.
-    pub fn remap_key_type<KC2>(self) -> RoRevRange<'txn, T, KC2, DC, C, IM> {
+    pub fn remap_key_type<KC2>(self) -> RoRevRange<'txn, KC2, DC, C, IM> {
         self.remap_types::<KC2, DC>()
     }
 
     /// Change the data codec type of this iterator, specifying the new codec.
-    pub fn remap_data_type<DC2>(self) -> RoRevRange<'txn, T, KC, DC2, C, IM> {
+    pub fn remap_data_type<DC2>(self) -> RoRevRange<'txn, KC, DC2, C, IM> {
         self.remap_types::<KC, DC2>()
     }
 
     /// Wrap the data bytes into a lazy decoder.
-    pub fn lazily_decode_data(self) -> RoRevRange<'txn, T, KC, LazyDecode<DC>, C, IM> {
+    pub fn lazily_decode_data(self) -> RoRevRange<'txn, KC, LazyDecode<DC>, C, IM> {
         self.remap_types::<KC, LazyDecode<DC>>()
     }
 }
 
-impl<'txn, T, KC, DC, C, IM> Iterator for RoRevRange<'txn, T, KC, DC, C, IM>
+impl<'txn, KC, DC, C, IM> Iterator for RoRevRange<'txn, KC, DC, C, IM>
 where
     KC: BytesDecode<'txn>,
     DC: BytesDecode<'txn>,
@@ -637,7 +637,7 @@ impl<KC, DC, C, IM> fmt::Debug for RoRevRange<'_, KC, DC, C, IM> {
     }
 }
 
-unsafe impl<KC, DC, C, IM> Send for RoRevRange<'_, WithoutTls, KC, DC, C, IM> {}
+unsafe impl<KC, DC, C, IM> Send for RoRevRange<'_, KC, DC, C, IM> {}
 
 /// A reverse read-write range iterator structure.
 pub struct RwRevRange<'txn, KC, DC, C = DefaultComparator, IM = MoveThroughDuplicateValues> {

--- a/heed/src/lib.rs
+++ b/heed/src/lib.rs
@@ -104,7 +104,7 @@ use self::mdb::ffi::{from_val, into_val};
 pub use self::mdb::flags::{DatabaseFlags, EnvFlags, PutFlags};
 pub use self::reserved_space::ReservedSpace;
 pub use self::traits::{BoxedError, BytesDecode, BytesEncode, Comparator, LexicographicComparator};
-pub use self::txn::{RoTxn, RwTxn, TlsUsage, WithTls, WithoutTls};
+pub use self::txn::{AnyTls, RoTxn, RwTxn, TlsUsage, WithTls, WithoutTls};
 
 /// The underlying LMDB library version information.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/heed/src/txn.rs
+++ b/heed/src/txn.rs
@@ -210,6 +210,8 @@ impl TlsUsage for WithoutTls {
 }
 
 impl TlsUsage for AnyTls {
+    // Users cannot open environments with AnyTls; therefore, this will never be read.
+    // We prefer to put the most restrictive value.
     const ENABLED: bool = false;
 }
 
@@ -273,7 +275,6 @@ impl<'p> RwTxn<'p> {
         Ok(RwTxn {
             txn: RoTxn {
                 inner: RoTxnInner { txn: NonNull::new(txn), env: Cow::Borrowed(&env.inner) },
-
                 _tls_marker: PhantomData,
             },
         })

--- a/heed/src/txn.rs
+++ b/heed/src/txn.rs
@@ -141,10 +141,28 @@ impl<'a> Deref for RoTxn<'a, WithTls> {
     }
 }
 
+#[cfg(master3)]
+impl std::ops::DerefMut for RoTxn<'_, WithTls> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: OK because repr(transparent) means RoTxn<T> always has the same layout
+        // as RoTxnInner.
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
 impl<'a> Deref for RoTxn<'a, WithoutTls> {
     type Target = RoTxn<'a, AnyTls>;
 
     fn deref(&self) -> &Self::Target {
+        // SAFETY: OK because repr(transparent) means RoTxn<T> always has the same layout
+        // as RoTxnInner.
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+#[cfg(master3)]
+impl std::ops::DerefMut for RoTxn<'_, WithoutTls> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         // SAFETY: OK because repr(transparent) means RoTxn<T> always has the same layout
         // as RoTxnInner.
         unsafe { std::mem::transmute(self) }

--- a/heed/src/txn.rs
+++ b/heed/src/txn.rs
@@ -335,3 +335,24 @@ impl std::ops::DerefMut for RwTxn<'_> {
         &mut self.txn
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn ro_txns_are_send() {
+        use crate::{RoTxn, WithoutTls};
+
+        fn is_send<T: Send>() {}
+
+        is_send::<RoTxn<WithoutTls>>();
+    }
+
+    #[test]
+    fn rw_txns_are_send() {
+        use crate::RwTxn;
+
+        fn is_send<T: Send>() {}
+
+        is_send::<RwTxn>();
+    }
+}

--- a/heed/src/txn.rs
+++ b/heed/src/txn.rs
@@ -2,8 +2,9 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::ptr::{self, NonNull};
+use std::sync::Arc;
 
-use crate::envs::Env;
+use crate::envs::{Env, EnvInner};
 use crate::mdb::error::mdb_result;
 use crate::mdb::ffi;
 use crate::Result;
@@ -46,11 +47,16 @@ use crate::Result;
 ///     }
 /// }
 /// ```
-pub struct RoTxn<'e, T = WithTls> {
+#[repr(transparent)]
+pub struct RoTxn<'e, T = AnyTls> {
+    inner: RoTxnInner<'e>,
+    _tls_marker: PhantomData<&'e T>,
+}
+
+struct RoTxnInner<'e> {
     /// Makes the struct covariant and !Sync
     pub(crate) txn: Option<NonNull<ffi::MDB_txn>>,
-    env: Cow<'e, Env<T>>,
-    _tls_marker: PhantomData<T>,
+    env: Cow<'e, Arc<EnvInner>>,
 }
 
 impl<'e, T> RoTxn<'e, T> {
@@ -66,7 +72,10 @@ impl<'e, T> RoTxn<'e, T> {
             ))?
         };
 
-        Ok(RoTxn { txn: NonNull::new(txn), env: Cow::Borrowed(env), _tls_marker: PhantomData })
+        Ok(RoTxn {
+            inner: RoTxnInner { txn: NonNull::new(txn), env: Cow::Borrowed(&env.inner) },
+            _tls_marker: PhantomData,
+        })
     }
 
     pub(crate) fn static_read_txn(env: Env<T>) -> Result<RoTxn<'static, T>> {
@@ -81,11 +90,18 @@ impl<'e, T> RoTxn<'e, T> {
             ))?
         };
 
-        Ok(RoTxn { txn: NonNull::new(txn), env: Cow::Owned(env), _tls_marker: PhantomData })
+        Ok(RoTxn {
+            inner: RoTxnInner { txn: NonNull::new(txn), env: Cow::Owned(env.inner) },
+            _tls_marker: PhantomData,
+        })
+    }
+
+    pub(crate) fn txn_ptr(&self) -> NonNull<ffi::MDB_txn> {
+        self.inner.txn.unwrap()
     }
 
     pub(crate) fn env_mut_ptr(&self) -> NonNull<ffi::MDB_env> {
-        self.env.env_mut_ptr()
+        self.inner.env.env_mut_ptr()
     }
 
     /// Return the transaction's ID.
@@ -94,7 +110,7 @@ impl<'e, T> RoTxn<'e, T> {
     /// [`RoTxn`], this corresponds to the snapshot being read;
     /// concurrent readers will frequently have the same transaction ID.
     pub fn id(&self) -> usize {
-        unsafe { ffi::mdb_txn_id(self.txn.unwrap().as_ptr()) }
+        unsafe { ffi::mdb_txn_id(self.inner.txn.unwrap().as_ptr()) }
     }
 
     /// Commit a read transaction.
@@ -109,15 +125,35 @@ impl<'e, T> RoTxn<'e, T> {
     pub fn commit(mut self) -> Result<()> {
         // Asserts that the transaction hasn't been already
         // committed/aborter and ensure we cannot use it twice.
-        let mut txn = self.txn.take().unwrap();
+        let mut txn = self.inner.txn.take().unwrap();
         let result = unsafe { mdb_result(ffi::mdb_txn_commit(txn.as_mut())) };
         result.map_err(Into::into)
     }
 }
 
+impl<'a> Deref for RoTxn<'a, WithTls> {
+    type Target = RoTxn<'a, AnyTls>;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: OK because repr(transparent) means RoTxn<T> always has the same layout
+        // as RoTxnInner.
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl<'a> Deref for RoTxn<'a, WithoutTls> {
+    type Target = RoTxn<'a, AnyTls>;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: OK because repr(transparent) means RoTxn<T> always has the same layout
+        // as RoTxnInner.
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
 impl<T> Drop for RoTxn<'_, T> {
     fn drop(&mut self) {
-        if let Some(mut txn) = self.txn.take() {
+        if let Some(mut txn) = self.inner.txn.take() {
             // Asserts that the transaction hasn't been already
             // committed/aborter and ensure we cannot use it twice.
             unsafe { ffi::mdb_txn_abort(txn.as_mut()) }
@@ -145,6 +181,12 @@ pub enum WithTls {}
 #[derive(Debug, PartialEq, Eq)]
 pub enum WithoutTls {}
 
+/// Parameter defining that read transactions might have been opened with or
+/// without Thread Local Storage (TLS).
+///
+/// `RwTxn`s and any `RoTxn` dereference to `&RoTxn<AnyTls>`.
+pub enum AnyTls {}
+
 /// Specificies if Thread Local Storage (TLS) must be used when
 /// opening transactions. It is often faster to open TLS-backed
 /// transactions but makes them `!Send`.
@@ -164,6 +206,10 @@ impl TlsUsage for WithTls {
 }
 
 impl TlsUsage for WithoutTls {
+    const ENABLED: bool = false;
+}
+
+impl TlsUsage for AnyTls {
     const ENABLED: bool = false;
 }
 
@@ -224,12 +270,10 @@ impl<'p> RwTxn<'p> {
             ))?
         };
 
-        let env_without_tls = unsafe { env.as_without_tls() };
-
         Ok(RwTxn {
             txn: RoTxn {
-                txn: NonNull::new(txn),
-                env: Cow::Borrowed(env_without_tls),
+                inner: RoTxnInner { txn: NonNull::new(txn), env: Cow::Borrowed(&env.inner) },
+
                 _tls_marker: PhantomData,
             },
         })
@@ -237,25 +281,22 @@ impl<'p> RwTxn<'p> {
 
     pub(crate) fn nested<T>(env: &'p Env<T>, parent: &'p mut RwTxn) -> Result<RwTxn<'p>> {
         let mut txn: *mut ffi::MDB_txn = ptr::null_mut();
-        let parent_ptr: *mut ffi::MDB_txn = unsafe { parent.txn.txn.unwrap().as_mut() };
+        let parent_ptr: *mut ffi::MDB_txn = unsafe { parent.txn.inner.txn.unwrap().as_mut() };
 
         unsafe {
             mdb_result(ffi::mdb_txn_begin(env.env_mut_ptr().as_mut(), parent_ptr, 0, &mut txn))?
         };
 
-        let env_without_tls = unsafe { env.as_without_tls() };
-
         Ok(RwTxn {
             txn: RoTxn {
-                txn: NonNull::new(txn),
-                env: Cow::Borrowed(env_without_tls),
+                inner: RoTxnInner { txn: NonNull::new(txn), env: Cow::Borrowed(&env.inner) },
                 _tls_marker: PhantomData,
             },
         })
     }
 
     pub(crate) fn env_mut_ptr(&self) -> NonNull<ffi::MDB_env> {
-        self.txn.env.env_mut_ptr()
+        self.txn.inner.env.env_mut_ptr()
     }
 
     /// Commit all the operations of a transaction into the database.
@@ -263,7 +304,7 @@ impl<'p> RwTxn<'p> {
     pub fn commit(mut self) -> Result<()> {
         // Asserts that the transaction hasn't been already
         // committed/aborter and ensure we cannot use it two times.
-        let mut txn = self.txn.txn.take().unwrap();
+        let mut txn = self.txn.inner.txn.take().unwrap();
         let result = unsafe { mdb_result(ffi::mdb_txn_commit(txn.as_mut())) };
         result.map_err(Into::into)
     }
@@ -273,7 +314,7 @@ impl<'p> RwTxn<'p> {
     pub fn abort(mut self) {
         // Asserts that the transaction hasn't been already
         // committed/aborter and ensure we cannot use it twice.
-        let mut txn = self.txn.txn.take().unwrap();
+        let mut txn = self.txn.inner.txn.take().unwrap();
         unsafe { ffi::mdb_txn_abort(txn.as_mut()) }
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #314 

## What does this PR do?
- Introduces `AnyTls`
- `RoTxn<T>` decay to `RoTxn<AnyTls>`
- To allow for transmutes, refactor `Env` and `RoTxn` to separate the phantom `T` (`WithTls`/`WithoutTls`/`AnyTls`) and the data + makes them repr transparent.
- Remove `T` from cursors: these types can never be `Send` because they morally have a reference to a `RoTxn`, which is not `Sync`.
- Removed the unsafe `Send` implementations of all the iterators.

