### PR TITLE
Add Dup Sort Custom Comparator support

### DIFF
--- a/examples/custom-dupsort-comparator.rs
+++ b/examples/custom-dupsort-comparator.rs
@@ -1,0 +1,62 @@
+use std::cmp::Ordering;
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+use byteorder::BigEndian;
+use heed::{DatabaseFlags, EnvOpenOptions};
+use heed_traits::Comparator;
+use heed_types::{Str, U128};
+
+enum DescendingIntCmp {}
+
+impl Comparator for DescendingIntCmp {
+    fn compare(a: &[u8], b: &[u8]) -> Ordering {
+        a.cmp(b).reverse()
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let env_path = Path::new("target").join("custom-dupsort-cmp.mdb");
+
+    let _ = fs::remove_dir_all(&env_path);
+
+    fs::create_dir_all(&env_path)?;
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .map_size(10 * 1024 * 1024) // 10MB
+            .max_dbs(3)
+            .open(env_path)?
+    };
+
+    let mut wtxn = env.write_txn()?;
+    let db = env
+        .database_options()
+        .types::<Str, U128<BigEndian>>()
+        .flags(DatabaseFlags::DUP_SORT)
+        .dup_sort_comparator::<DescendingIntCmp>()
+        .create(&mut wtxn)?;
+    wtxn.commit()?;
+
+    let mut wtxn = env.write_txn()?;
+
+    // We fill our database with entries.
+    db.put(&mut wtxn, "1", &1)?;
+    db.put(&mut wtxn, "1", &2)?;
+    db.put(&mut wtxn, "1", &3)?;
+    db.put(&mut wtxn, "2", &4)?;
+    db.put(&mut wtxn, "1", &5)?;
+    db.put(&mut wtxn, "0", &0)?;
+
+    // We check that the keys are in lexicographic and values in descending order.
+    let mut iter = db.iter(&wtxn)?;
+    assert_eq!(iter.next().transpose()?, Some(("0", 0)));
+    assert_eq!(iter.next().transpose()?, Some(("1", 5)));
+    assert_eq!(iter.next().transpose()?, Some(("1", 3)));
+    assert_eq!(iter.next().transpose()?, Some(("1", 2)));
+    assert_eq!(iter.next().transpose()?, Some(("1", 1)));
+    assert_eq!(iter.next().transpose()?, Some(("2", 4)));
+    drop(iter);
+
+    Ok(())
+}

--- a/heed/Cargo.toml
+++ b/heed/Cargo.toml
@@ -132,6 +132,10 @@ name = "custom-comparator"
 path = "../examples/custom-comparator.rs"
 
 [[example]]
+name = "custom-dupsort-comparator"
+path = "../examples/custom-dupsort-comparator.rs"
+
+[[example]]
 name = "multi-env"
 path = "../examples/multi-env.rs"
 

--- a/heed/src/cookbook.rs
+++ b/heed/src/cookbook.rs
@@ -5,6 +5,8 @@
 //! - [Create Custom and Prefix Codecs](#create-custom-and-prefix-codecs)
 //! - [Change the Environment Size Dynamically](#change-the-environment-size-dynamically)
 //! - [Advanced Multithreaded Access of Entries](#advanced-multithreaded-access-of-entries)
+//! - [Use Custom Key Comparator](#use-custom-key-comparator)
+//! - [Use Custom Dupsort Comparator](#use-custom-dupsort-comparator)
 //!
 //! # Decode Values on Demand
 //!
@@ -441,9 +443,146 @@
 //! unsafe impl Sync for ImmutableMap<'_> {}
 //! ```
 //!
+//! # Use Custom Key Comparator
+//!
+//! LMDB keys are sorted in lexicographic order by default. To change this behavior
+//! you can implement a custom [`Comparator`] and provide it when creating the database.
+//!
+//! Under the hood this translates into a [`mdb_set_compare`] call.
+//!
+//! ```
+//! use std::cmp::Ordering;
+//! use std::error::Error;
+//! use std::str;
+//!
+//! use heed::EnvOpenOptions;
+//! use heed_traits::Comparator;
+//! use heed_types::{Str, Unit};
+//!
+//! enum StringAsIntCmp {}
+//!
+//! // This function takes two strings which represent integers,
+//! // parses them into i32s and compare the parsed value.
+//! // Therefore "-1000" < "-100" must be true even without '0' padding.
+//! impl Comparator for StringAsIntCmp {
+//!     fn compare(a: &[u8], b: &[u8]) -> Ordering {
+//!         let a: i32 = str::from_utf8(a).unwrap().parse().unwrap();
+//!         let b: i32 = str::from_utf8(b).unwrap().parse().unwrap();
+//!         a.cmp(&b)
+//!     }
+//! }
+//!
+//! fn main() -> Result<(), Box<dyn Error>> {
+//!     let path = tempfile::tempdir()?;
+//!
+//!     let env = unsafe {
+//!         EnvOpenOptions::new()
+//!             .map_size(10 * 1024 * 1024) // 10MB
+//!             .max_dbs(3)
+//!             .open(path)?
+//!     };
+//!
+//!     let mut wtxn = env.write_txn()?;
+//!     let db = env
+//!         .database_options()
+//!         .types::<Str, Unit>()
+//!         .key_comparator::<StringAsIntCmp>()
+//!         .create(&mut wtxn)?;
+//!     wtxn.commit()?;
+//!
+//!     let mut wtxn = env.write_txn()?;
+//!
+//!     // We fill our database with entries.
+//!     db.put(&mut wtxn, "-100000", &())?;
+//!     db.put(&mut wtxn, "-10000", &())?;
+//!     db.put(&mut wtxn, "-1000", &())?;
+//!     db.put(&mut wtxn, "-100", &())?;
+//!     db.put(&mut wtxn, "100", &())?;
+//!
+//!     // We check that the key are in the right order ("-100" < "-1000" < "-10000"...)
+//!     let mut iter = db.iter(&wtxn)?;
+//!     assert_eq!(iter.next().transpose()?, Some(("-100000", ())));
+//!     assert_eq!(iter.next().transpose()?, Some(("-10000", ())));
+//!     assert_eq!(iter.next().transpose()?, Some(("-1000", ())));
+//!     assert_eq!(iter.next().transpose()?, Some(("-100", ())));
+//!     assert_eq!(iter.next().transpose()?, Some(("100", ())));
+//!     drop(iter);
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! # Use Custom Dupsort Comparator
+//!
+//! When using DUPSORT LMDB sorts values of the same key in lexicographic order by default.
+//! To change this behavior you can implement a custom [`Comparator`] and provide it when
+//! creating the database.
+//!
+//! Under the hood this translates into a [`mdb_set_dupsort`] call.
+//!
+//! ```
+//! use std::cmp::Ordering;
+//! use std::error::Error;
+//!
+//! use byteorder::BigEndian;
+//! use heed::{DatabaseFlags, EnvOpenOptions};
+//! use heed_traits::Comparator;
+//! use heed_types::{Str, U128};
+//!
+//! enum DescendingIntCmp {}
+//!
+//! impl Comparator for DescendingIntCmp {
+//!     fn compare(a: &[u8], b: &[u8]) -> Ordering {
+//!         a.cmp(&b).reverse()
+//!     }
+//! }
+//!
+//! fn main() -> Result<(), Box<dyn Error>> {
+//!     let path = tempfile::tempdir()?;
+//!
+//!     let env = unsafe {
+//!         EnvOpenOptions::new()
+//!             .map_size(10 * 1024 * 1024) // 10MB
+//!             .max_dbs(3)
+//!             .open(path)?
+//!     };
+//!
+//!     let mut wtxn = env.write_txn()?;
+//!     let db = env
+//!         .database_options()
+//!         .types::<Str, U128<BigEndian>>()
+//!         .flags(DatabaseFlags::DUP_SORT)
+//!         .dup_sort_comparator::<DescendingIntCmp>()
+//!         .create(&mut wtxn)?;
+//!     wtxn.commit()?;
+//!
+//!     let mut wtxn = env.write_txn()?;
+//!
+//!     // We fill our database with entries.
+//!     db.put(&mut wtxn, "1", &1)?;
+//!     db.put(&mut wtxn, "1", &2)?;
+//!     db.put(&mut wtxn, "1", &3)?;
+//!     db.put(&mut wtxn, "2", &4)?;
+//!     db.put(&mut wtxn, "1", &5)?;
+//!     db.put(&mut wtxn, "0", &0)?;
+//!
+//!     // We check that the keys are in lexicographic and values in descending order.
+//!     let mut iter = db.iter(&wtxn)?;
+//!     assert_eq!(iter.next().transpose()?, Some(("0", 0)));
+//!     assert_eq!(iter.next().transpose()?, Some(("1", 5)));
+//!     assert_eq!(iter.next().transpose()?, Some(("1", 3)));
+//!     assert_eq!(iter.next().transpose()?, Some(("1", 2)));
+//!     assert_eq!(iter.next().transpose()?, Some(("1", 1)));
+//!     assert_eq!(iter.next().transpose()?, Some(("2", 4)));
+//!     drop(iter);
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
 
 // To let cargo generate doc links
 #![allow(unused_imports)]
 
-use crate::envs::EnvOpenOptions;
-use crate::{BytesDecode, BytesEncode, Database};
+use crate::mdb::ffi::{mdb_set_compare, mdb_set_dupsort};
+use crate::{BytesDecode, BytesEncode, Comparator, Database, EnvOpenOptions};

--- a/heed/src/databases/database.rs
+++ b/heed/src/databases/database.rs
@@ -2707,20 +2707,21 @@ impl<KC, DC, C, CDUP> Database<KC, DC, C, CDUP> {
     }
 }
 
-impl<KC, DC, C> Clone for Database<KC, DC, C> {
-    fn clone(&self) -> Database<KC, DC, C> {
+impl<KC, DC, C, CDUP> Clone for Database<KC, DC, C, CDUP> {
+    fn clone(&self) -> Database<KC, DC, C, CDUP> {
         *self
     }
 }
 
-impl<KC, DC, C> Copy for Database<KC, DC, C> {}
+impl<KC, DC, C, CDUP> Copy for Database<KC, DC, C, CDUP> {}
 
-impl<KC, DC, C> fmt::Debug for Database<KC, DC, C> {
+impl<KC, DC, C, CDUP> fmt::Debug for Database<KC, DC, C, CDUP> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Database")
             .field("key_codec", &any::type_name::<KC>())
             .field("data_codec", &any::type_name::<DC>())
-            .field("comparator", &any::type_name::<C>())
+            .field("key_comparator", &any::type_name::<C>())
+            .field("dup_sort_comparator", &any::type_name::<CDUP>())
             .finish()
     }
 }

--- a/heed/src/databases/encrypted_database.rs
+++ b/heed/src/databases/encrypted_database.rs
@@ -88,6 +88,15 @@ impl<'e, 'n, T, KC, DC, C, CDUP> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC,
         EncryptedDatabaseOpenOptions { inner: self.inner.key_comparator() }
     }
 
+    /// Change the customized dup sort compare function of the database.
+    ///
+    /// By default no customized compare function will be set when opening a database.
+    pub fn dup_sort_comparator<NCDUP>(
+        self,
+    ) -> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C, NCDUP> {
+        EncryptedDatabaseOpenOptions { inner: self.inner.dup_sort_comparator() }
+    }
+
     /// Change the name of the database.
     ///
     /// By default the database is unnamed and there only is a single unnamed database.

--- a/heed/src/databases/encrypted_database.rs
+++ b/heed/src/databases/encrypted_database.rs
@@ -53,8 +53,16 @@ use crate::*;
 /// # Ok(()) }
 /// ```
 #[derive(Debug)]
-pub struct EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C = DefaultComparator> {
-    inner: DatabaseOpenOptions<'e, 'n, T, KC, DC, C>,
+pub struct EncryptedDatabaseOpenOptions<
+    'e,
+    'n,
+    T,
+    KC,
+    DC,
+    C = DefaultComparator,
+    CDUP = DefaultComparator,
+> {
+    inner: DatabaseOpenOptions<'e, 'n, T, KC, DC, C, CDUP>,
 }
 
 impl<'e, T> EncryptedDatabaseOpenOptions<'e, 'static, T, Unspecified, Unspecified> {
@@ -64,7 +72,7 @@ impl<'e, T> EncryptedDatabaseOpenOptions<'e, 'static, T, Unspecified, Unspecifie
     }
 }
 
-impl<'e, 'n, T, KC, DC, C> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
+impl<'e, 'n, T, KC, DC, C, CDUP> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C, CDUP> {
     /// Change the type of the database.
     ///
     /// The default types are [`Unspecified`] and require a call to [`Database::remap_types`]
@@ -72,10 +80,11 @@ impl<'e, 'n, T, KC, DC, C> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
     pub fn types<NKC, NDC>(self) -> EncryptedDatabaseOpenOptions<'e, 'n, T, NKC, NDC> {
         EncryptedDatabaseOpenOptions { inner: self.inner.types() }
     }
+
     /// Change the customized key compare function of the database.
     ///
     /// By default no customized compare function will be set when opening a database.
-    pub fn key_comparator<NC>(self) -> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, NC> {
+    pub fn key_comparator<NC>(self) -> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, NC, CDUP> {
         EncryptedDatabaseOpenOptions { inner: self.inner.key_comparator() }
     }
 
@@ -111,11 +120,12 @@ impl<'e, 'n, T, KC, DC, C> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
     ///
     /// If not done, you might raise `Io(Os { code: 22, kind: InvalidInput, message: "Invalid argument" })`
     /// known as `EINVAL`.
-    pub fn open(&self, rtxn: &RoTxn) -> Result<Option<EncryptedDatabase<KC, DC, C>>>
+    pub fn open(&self, rtxn: &RoTxn) -> Result<Option<EncryptedDatabase<KC, DC, C, CDUP>>>
     where
         KC: 'static,
         DC: 'static,
         C: Comparator + 'static,
+        CDUP: Comparator + 'static,
     {
         self.inner.open(rtxn).map(|opt| opt.map(EncryptedDatabase::new))
     }
@@ -129,23 +139,24 @@ impl<'e, 'n, T, KC, DC, C> EncryptedDatabaseOpenOptions<'e, 'n, T, KC, DC, C> {
     /// LMDB has an important restriction on the unnamed database when named ones are opened.
     /// The names of the named databases are stored as keys in the unnamed one and are immutable,
     /// and these keys can only be read and not written.
-    pub fn create(&self, wtxn: &mut RwTxn) -> Result<EncryptedDatabase<KC, DC, C>>
+    pub fn create(&self, wtxn: &mut RwTxn) -> Result<EncryptedDatabase<KC, DC, C, CDUP>>
     where
         KC: 'static,
         DC: 'static,
         C: Comparator + 'static,
+        CDUP: Comparator + 'static,
     {
         self.inner.create(wtxn).map(EncryptedDatabase::new)
     }
 }
 
-impl<T, KC, DC, C> Clone for EncryptedDatabaseOpenOptions<'_, '_, T, KC, DC, C> {
+impl<T, KC, DC, C, CDUP> Clone for EncryptedDatabaseOpenOptions<'_, '_, T, KC, DC, C, CDUP> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<T, KC, DC, C> Copy for EncryptedDatabaseOpenOptions<'_, '_, T, KC, DC, C> {}
+impl<T, KC, DC, C, CDUP> Copy for EncryptedDatabaseOpenOptions<'_, '_, T, KC, DC, C, CDUP> {}
 
 /// A typed database that accepts only the types it was created with.
 ///
@@ -259,12 +270,12 @@ impl<T, KC, DC, C> Copy for EncryptedDatabaseOpenOptions<'_, '_, T, KC, DC, C> {
 /// wtxn.commit()?;
 /// # Ok(()) }
 /// ```
-pub struct EncryptedDatabase<KC, DC, C = DefaultComparator> {
-    inner: Database<KC, DC, C>,
+pub struct EncryptedDatabase<KC, DC, C = DefaultComparator, CDUP = DefaultComparator> {
+    inner: Database<KC, DC, C, CDUP>,
 }
 
-impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
-    pub(crate) fn new(inner: Database<KC, DC, C>) -> EncryptedDatabase<KC, DC, C> {
+impl<KC, DC, C, CDUP> EncryptedDatabase<KC, DC, C, CDUP> {
+    pub(crate) fn new(inner: Database<KC, DC, C, CDUP>) -> EncryptedDatabase<KC, DC, C, CDUP> {
         EncryptedDatabase { inner }
     }
 
@@ -2228,20 +2239,21 @@ impl<KC, DC, C> EncryptedDatabase<KC, DC, C> {
     }
 }
 
-impl<KC, DC, C> Clone for EncryptedDatabase<KC, DC, C> {
-    fn clone(&self) -> EncryptedDatabase<KC, DC, C> {
+impl<KC, DC, C, CDUP> Clone for EncryptedDatabase<KC, DC, C, CDUP> {
+    fn clone(&self) -> EncryptedDatabase<KC, DC, C, CDUP> {
         *self
     }
 }
 
-impl<KC, DC, C> Copy for EncryptedDatabase<KC, DC, C> {}
+impl<KC, DC, C, CDUP> Copy for EncryptedDatabase<KC, DC, C, CDUP> {}
 
-impl<KC, DC, C> fmt::Debug for EncryptedDatabase<KC, DC, C> {
+impl<KC, DC, C, CDUP> fmt::Debug for EncryptedDatabase<KC, DC, C, CDUP> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("EncryptedDatabase")
             .field("key_codec", &any::type_name::<KC>())
             .field("data_codec", &any::type_name::<DC>())
-            .field("comparator", &any::type_name::<C>())
+            .field("key_comparator", &any::type_name::<C>())
+            .field("dup_sort_comparator", &any::type_name::<CDUP>())
             .finish()
     }
 }

--- a/heed/src/envs/mod.rs
+++ b/heed/src/envs/mod.rs
@@ -222,13 +222,13 @@ impl LexicographicComparator for DefaultComparator {
     }
 }
 
-/// A representation of LMDB's `MDB_INTEGERKEY` comparator behavior.
+/// A representation of LMDB's `MDB_INTEGERKEY` and `MDB_INTEGERDUP` comparator behavior.
 ///
 /// This enum is used to indicate a table should be sorted by the keys numeric
 /// value in native byte order. When a [`Database`] is created or opened with
 /// [`IntegerComparator`], it signifies that the comparator should not be explicitly
 /// set via [`ffi::mdb_set_compare`], instead the flag [`DatabaseFlags::INTEGER_KEY`]
-/// is set on the table.
+/// or [`DatabaseFlags::INTEGER_DUP`] is set on the table.
 ///
 /// This can only be used on certain types: either `u32` or `usize`.
 /// The keys must all be of the same size.

--- a/heed/src/mdb/lmdb_ffi.rs
+++ b/heed/src/mdb/lmdb_ffi.rs
@@ -6,9 +6,9 @@ pub use ffi::{
     mdb_env_get_fd, mdb_env_get_flags, mdb_env_get_maxkeysize, mdb_env_get_maxreaders,
     mdb_env_info, mdb_env_open, mdb_env_set_flags, mdb_env_set_mapsize, mdb_env_set_maxdbs,
     mdb_env_set_maxreaders, mdb_env_stat, mdb_env_sync, mdb_filehandle_t, mdb_get, mdb_put,
-    mdb_reader_check, mdb_set_compare, mdb_stat, mdb_txn_abort, mdb_txn_begin, mdb_txn_commit,
-    mdb_txn_id, mdb_version, MDB_cursor, MDB_dbi, MDB_env, MDB_stat, MDB_txn, MDB_val,
-    MDB_CP_COMPACT, MDB_CURRENT, MDB_RDONLY, MDB_RESERVE,
+    mdb_reader_check, mdb_set_compare, mdb_set_dupsort, mdb_stat, mdb_txn_abort, mdb_txn_begin,
+    mdb_txn_commit, mdb_txn_id, mdb_version, MDB_cursor, MDB_dbi, MDB_env, MDB_stat, MDB_txn,
+    MDB_val, MDB_CP_COMPACT, MDB_CURRENT, MDB_RDONLY, MDB_RESERVE,
 };
 #[cfg(master3)]
 pub use ffi::{mdb_env_set_encrypt, MDB_enc_func};

--- a/heed/src/mdb/lmdb_flags.rs
+++ b/heed/src/mdb/lmdb_flags.rs
@@ -233,7 +233,7 @@ bitflags! {
         /// wtxn.commit()?;
         /// # Ok(()) }
         /// ```
-        #[deprecated(since="0.21.0", note="please use `IntegerComparator` instead")]
+        #[deprecated(since="0.21.0", note="prefer using `IntegerComparator` with the `DatabaseOpenOptions::key_comparator` method instead")]
         const INTEGER_KEY = ffi::MDB_INTEGERKEY;
         /// With [`DatabaseFlags::DUP_SORT`], sorted dup items have fixed size.
         ///
@@ -354,6 +354,7 @@ bitflags! {
         /// wtxn.commit()?;
         /// # Ok(()) }
         /// ```
+        #[deprecated(since="0.22.0", note="prefer using `IntegerComparator` with the `DatabaseOpenOptions::dup_sort_comparator` method instead")]
         const INTEGER_DUP = ffi::MDB_INTEGERDUP;
         /// With [`DatabaseFlags::DUP_SORT`], use reverse string dups.
         ///

--- a/heed/src/mdb/lmdb_flags.rs
+++ b/heed/src/mdb/lmdb_flags.rs
@@ -103,10 +103,10 @@ bitflags! {
         /// # db.clear(&mut wtxn)?;
         /// db.put(&mut wtxn, &"bonjour", &())?;
         /// db.put(&mut wtxn, &"hello", &())?;
-        /// db.put(&mut wtxn, &"holla", &())?;
+        /// db.put(&mut wtxn, &"hola", &())?;
         ///
         /// let mut iter = db.iter(&wtxn)?;
-        /// assert_eq!(iter.next().transpose()?, Some(("holla", ())));
+        /// assert_eq!(iter.next().transpose()?, Some(("hola", ())));
         /// assert_eq!(iter.next().transpose()?, Some(("hello", ())));
         /// assert_eq!(iter.next().transpose()?, Some(("bonjour", ())));
         /// assert_eq!(iter.next().transpose()?, None);
@@ -115,7 +115,7 @@ bitflags! {
         /// let mut iter = db.rev_iter(&wtxn)?;
         /// assert_eq!(iter.next().transpose()?, Some(("bonjour", ())));
         /// assert_eq!(iter.next().transpose()?, Some(("hello", ())));
-        /// assert_eq!(iter.next().transpose()?, Some(("holla", ())));
+        /// assert_eq!(iter.next().transpose()?, Some(("hola", ())));
         /// assert_eq!(iter.next().transpose()?, None);
         /// drop(iter);
         ///
@@ -382,12 +382,12 @@ bitflags! {
         ///
         /// # db.clear(&mut wtxn)?;
         /// db.put(&mut wtxn, &68, &"bonjour")?;
-        /// db.put(&mut wtxn, &68, &"holla")?;
+        /// db.put(&mut wtxn, &68, &"hola")?;
         /// db.put(&mut wtxn, &68, &"hello")?;
         /// db.put(&mut wtxn, &92, &"hallo")?;
         ///
         /// let mut iter = db.get_duplicates(&wtxn, &68)?.expect("the key exists");
-        /// assert_eq!(iter.next().transpose()?, Some((68, "holla")));
+        /// assert_eq!(iter.next().transpose()?, Some((68, "hola")));
         /// assert_eq!(iter.next().transpose()?, Some((68, "hello")));
         /// assert_eq!(iter.next().transpose()?, Some((68, "bonjour")));
         /// assert_eq!(iter.next().transpose()?, None);


### PR DESCRIPTION
Superseeds and, therefore, fixes #283 and fixes #284.