### PR TITLE
Setting `NDEBUG` on release builds

### DIFF
--- a/lmdb-master-sys/build.rs
+++ b/lmdb-master-sys/build.rs
@@ -157,5 +157,9 @@ fn main() {
         builder.define("MDB_MAXKEYSIZE", "0");
     }
 
+    if !cfg!(debug_assertions) {
+        builder.define("NDEBUG", None);
+    }
+
     builder.compile("liblmdb.a")
 }

--- a/lmdb-master3-sys/build.rs
+++ b/lmdb-master3-sys/build.rs
@@ -157,5 +157,9 @@ fn main() {
         builder.define("MDB_MAXKEYSIZE", "0");
     }
 
+    if !cfg!(debug_assertions) {
+        builder.define("NDEBUG", None);
+    }
+
     builder.compile("liblmdb.a")
 }


### PR DESCRIPTION
When building LMDB in non-debug (release) it should set the `NDEBUG` env variable so that LMDB is compiled in non-debug. We should see perf improvements. Fixes #322.