### PR TITLE
Implement Send on Cursors so we can move them between threads

### DIFF
--- a/heed/src/cursor.rs
+++ b/heed/src/cursor.rs
@@ -1,4 +1,5 @@
 use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
 use std::{marker, mem, ptr};
 
 use crate::mdb::error::mdb_result;
@@ -6,7 +7,7 @@ use crate::mdb::ffi;
 use crate::*;
 
 pub struct RoCursor<'txn> {
-    cursor: *mut ffi::MDB_cursor,
+    cursor: NonNull<ffi::MDB_cursor>,
     _marker: marker::PhantomData<&'txn ()>,
 }
 
@@ -15,7 +16,7 @@ impl<'txn> RoCursor<'txn> {
         let mut cursor: *mut ffi::MDB_cursor = ptr::null_mut();
         let mut txn = txn.txn_ptr();
         unsafe { mdb_result(ffi::mdb_cursor_open(txn.as_mut(), dbi, &mut cursor))? }
-        Ok(RoCursor { cursor, _marker: marker::PhantomData })
+        Ok(RoCursor { cursor: NonNull::new(cursor).unwrap(), _marker: marker::PhantomData })
     }
 
     pub fn current(&mut self) -> Result<Option<(&'txn [u8], &'txn [u8])>> {
@@ -241,6 +242,8 @@ impl Drop for RoCursor<'_> {
         unsafe { ffi::mdb_cursor_close(self.cursor) }
     }
 }
+
+unsafe impl Send for RoCursor<'_> {}
 
 pub struct RwCursor<'txn> {
     cursor: RoCursor<'txn>,


### PR DESCRIPTION
This PR implements [`Send` on the LMDB cursors struct wrapper](https://doc.rust-lang.org/stable/std/marker/trait.Send.html). The goal is to move database iterators between threads.
If this PR is merged, we must release a v0.22.1 patch. This change is not breaking.

---

Hey @hyc 👋

Is it valid to move cursors between threads? [Nothing in the documentation](https://github.com/LMDB/lmdb/blob/f20e41de09d97e4461946b7e26ec831d0c24fac7/libraries/liblmdb/lmdb.h#L1409-L1431) seems to prevent that, and nothing in the code prevents it either. Note that cursors are always deallocated when dropped (going out of scope). So, I only fear that we create a cursor on one thread and deallocate it on another. However, allocations are done with malloc, so it looks safe.

Thank you and have a lovely week 🍀