### PR TITLE
Introduce `static_write_txn`

### DIFF
--- a/heed/src/envs/encrypted_env.rs
+++ b/heed/src/envs/encrypted_env.rs
@@ -176,6 +176,8 @@ impl<T> EncryptedEnv<T> {
 
     /// Create a transaction with read and write access for use with the environment.
     ///
+    /// See [`Self::static_write_txn`] if you want the txn to own the environment.
+    ///
     /// ## LMDB Limitations
     ///
     /// Only one [`RwTxn`] may exist simultaneously in the current environment.
@@ -184,6 +186,20 @@ impl<T> EncryptedEnv<T> {
     /// transaction.
     pub fn write_txn(&self) -> Result<RwTxn<'_>> {
         self.inner.write_txn()
+    }
+
+    /// Create a transaction with read and write access for use with the environment.
+    /// Contrary to [`Self::write_txn`], this version **owns** the environment, which
+    /// means you won't be able to close the environment while this transaction is alive.
+    ///
+    /// ## LMDB Limitations
+    ///
+    /// Only one [`RwTxn`] may exist simultaneously in the current environment.
+    /// If another write transaction is initiated, while another write transaction exists
+    /// the thread initiating the new one will wait on a mutex upon completion of the previous
+    /// transaction.
+    pub fn static_write_txn(self) -> Result<RwTxn<'static>> {
+        self.inner.static_write_txn()
     }
 
     /// Create a nested transaction with read and write access for use with the environment.

--- a/heed/src/envs/env.rs
+++ b/heed/src/envs/env.rs
@@ -374,6 +374,8 @@ impl<T> Env<T> {
 
     /// Create a transaction with read and write access for use with the environment.
     ///
+    /// See [`Self::static_write_txn`] if you want the txn to own the environment.
+    ///
     /// ## LMDB Limitations
     ///
     /// Only one [`RwTxn`] may exist simultaneously in the current environment.
@@ -382,6 +384,20 @@ impl<T> Env<T> {
     /// transaction.
     pub fn write_txn(&self) -> Result<RwTxn<'_>> {
         RwTxn::new(self)
+    }
+
+    /// Create a transaction with read and write access for use with the environment.
+    /// Contrary to [`Self::write_txn`], this version **owns** the environment, which
+    /// means you won't be able to close the environment while this transaction is alive.
+    ///
+    /// ## LMDB Limitations
+    ///
+    /// Only one [`RwTxn`] may exist simultaneously in the current environment.
+    /// If another write transaction is initiated, while another write transaction exists
+    /// the thread initiating the new one will wait on a mutex upon completion of the previous
+    /// transaction.
+    pub fn static_write_txn(self) -> Result<RwTxn<'static>> {
+        RwTxn::static_write_txn(self)
     }
 
     /// Create a nested transaction with read and write access for use with the environment.

--- a/heed/src/txn.rs
+++ b/heed/src/txn.rs
@@ -279,6 +279,14 @@ pub struct RwTxn<'p> {
 
 impl<'p> RwTxn<'p> {
     pub(crate) fn new<T>(env: &'p Env<T>) -> Result<RwTxn<'p>> {
+        Self::begin(Cow::Borrowed(&env.inner))
+    }
+
+    pub(crate) fn static_write_txn<T>(env: Env<T>) -> Result<RwTxn<'static>> {
+        Self::begin(Cow::Owned(env.inner))
+    }
+
+    fn begin(env: Cow<'_, Arc<EnvInner>>) -> Result<RwTxn<'_>> {
         let mut txn: *mut ffi::MDB_txn = ptr::null_mut();
 
         unsafe {
@@ -292,7 +300,7 @@ impl<'p> RwTxn<'p> {
 
         Ok(RwTxn {
             txn: RoTxn {
-                inner: RoTxnInner { txn: NonNull::new(txn), env: Cow::Borrowed(&env.inner) },
+                inner: RoTxnInner { txn: NonNull::new(txn), env },
                 _tls_marker: PhantomData,
             },
         })


### PR DESCRIPTION
# Pull Request

## What does this PR do?
  - Adds `Env::static_write_txn` and `EncryptedEnv::static_write_txn`, mirroring the existing `static_read_txn` API. These constructors consume the env (`self`) and return an
   `RwTxn<'static>` whose lifetime is no longer tied to a borrowed `Env`, letting callers hold a write txn without keeping a separate `Env` reference alive.
  - Implementation in `heed/src/txn.rs` mirrors `RwTxn::static_read_txn`: begins an `mdb_txn_begin` write transaction and stores the env as `Cow::Owned` inside `RoTxnInner`
  so the env cannot be closed while the txn lives.
  - Updates the `write_txn` rustdoc on both `Env` and `EncryptedEnv` to cross-reference the new `static_write_txn`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
    - Used Claude Code to explore the repo structure and locate the existing `static_read_txn` implementation, then mirrored its shape for `static_write_txn` (env consumed by value, `Cow::Owned` env handle, `'static` lifetime on the returned txn). Final code and docs were reviewed by hand.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
